### PR TITLE
Backend in-memory provider

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,8 @@ issues:
       text: "use of `log.Fatalf` forbidden by pattern"
     - path: cmd/example/main.go
       text: "use of `log.Printf` forbidden by pattern"
+    - path: internal/memory/backend.go
+      text: "use of `log.Printf` forbidden by pattern"
 linters:
   enable:
     - asciicheck

--- a/client/api_provider.go
+++ b/client/api_provider.go
@@ -282,7 +282,7 @@ func (a *apiProvider) GetJSONFeature(ctx context.Context, key string, namespace 
 		return errors.Wrap(err, "error hitting lekko backend")
 	}
 	if err := json.Unmarshal(resp.Msg.GetValue(), result); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to unmarshal json into go type %T", result))
+		return errors.Wrapf(err, "failed to unmarshal json into go type %T", result)
 	}
 	return nil
 }

--- a/client/in_memory_provider.go
+++ b/client/in_memory_provider.go
@@ -1,0 +1,144 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/lekkodev/go-sdk/internal/memory"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type InMemoryProviderOptions struct {
+	// API key used to communicate with Lekko.
+	// lekko_**********
+	APIKey string
+	// Repository Key of the configuration repository you wish to read
+	// configs from.
+	RepositoryKey RepositoryKey
+	// Interval at which you want to refresh configs from Lekko.
+	// Recommend 15 to 30 seconds.
+	UpdateInterval time.Duration
+}
+
+type inMemoryProviderType string
+
+const (
+	inMemoryProviderTypeBackend inMemoryProviderType = "backend"
+
+	minUpdateInterval = time.Second
+)
+
+// Constructs a provider that refreshes configs from Lekko backend repeatedly in the background,
+// caching the configs in-memory.
+func BackendInMemoryProvider(ctx context.Context, opts *InMemoryProviderOptions) (Provider, error) {
+	if err := opts.validate(inMemoryProviderTypeBackend); err != nil {
+		return nil, err
+	}
+	backend, err := memory.NewBackendStore(ctx, opts.APIKey, defaultAPIURL, opts.RepositoryKey.OwnerName, opts.RepositoryKey.RepoName, opts.UpdateInterval)
+	if err != nil {
+		return nil, err
+	}
+	return &inMemoryProvider{
+		store: backend,
+	}, nil
+}
+
+func (opts *InMemoryProviderOptions) validate(t inMemoryProviderType) error {
+	if opts == nil {
+		return errors.New("options cannot be nil")
+	}
+	if t == inMemoryProviderTypeBackend && len(opts.APIKey) == 0 {
+		return errors.New("no apikey given for backend provider")
+	}
+	if len(opts.RepositoryKey.OwnerName) == 0 || len(opts.RepositoryKey.RepoName) == 0 {
+		return errors.New("incomplete repository key given")
+	}
+	if opts.UpdateInterval.Seconds() < minUpdateInterval.Seconds() {
+		return errors.Errorf("update interval too small, minimum %s", minUpdateInterval)
+	}
+	return nil
+}
+
+type inMemoryProvider struct {
+	store memory.Store
+}
+
+// Close implements Provider.
+func (im *inMemoryProvider) Close(ctx context.Context) error {
+	return im.store.Close(ctx)
+}
+
+// GetBoolFeature implements Provider.
+func (im *inMemoryProvider) GetBoolFeature(ctx context.Context, key string, namespace string) (bool, error) {
+	dest := &wrapperspb.BoolValue{}
+	if err := im.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
+		return false, err
+	}
+	return dest.GetValue(), nil
+}
+
+// GetFloatFeature implements Provider.
+func (im *inMemoryProvider) GetFloatFeature(ctx context.Context, key string, namespace string) (float64, error) {
+	dest := &wrapperspb.DoubleValue{}
+	if err := im.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
+		return 0, err
+	}
+	return dest.GetValue(), nil
+}
+
+// GetIntFeature implements Provider.
+func (im *inMemoryProvider) GetIntFeature(ctx context.Context, key string, namespace string) (int64, error) {
+	dest := &wrapperspb.Int64Value{}
+	if err := im.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
+		return 0, err
+	}
+	return dest.GetValue(), nil
+}
+
+// GetJSONFeature implements Provider.
+func (im *inMemoryProvider) GetJSONFeature(ctx context.Context, key string, namespace string, result interface{}) error {
+	dest := &structpb.Value{}
+	if err := im.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
+		return err
+	}
+	bytes, err := dest.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(bytes, result); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal json into go type %T", result)
+	}
+	return nil
+}
+
+// GetProtoFeature implements Provider.
+func (im *inMemoryProvider) GetProtoFeature(ctx context.Context, key string, namespace string, result protoreflect.ProtoMessage) error {
+	return im.store.Evaluate(key, namespace, fromContext(ctx), result)
+}
+
+// GetStringFeature implements Provider.
+func (im *inMemoryProvider) GetStringFeature(ctx context.Context, key string, namespace string) (string, error) {
+	dest := &wrapperspb.StringValue{}
+	if err := im.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
+		return "", err
+	}
+	return dest.GetValue(), nil
+}

--- a/client/in_memory_provider_test.go
+++ b/client/in_memory_provider_test.go
@@ -1,0 +1,139 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
+	"github.com/lekkodev/go-sdk/internal/fixtures"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func makeConfigs() map[string]*anypb.Any {
+	ret := make(map[string]*anypb.Any)
+	bf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true)
+	ret["bool"] = bf.GetFeature().GetTree().GetDefault()
+	sf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo")
+	ret["string"] = sf.GetFeature().GetTree().GetDefault()
+	intf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42))
+	ret["int"] = intf.GetFeature().GetTree().GetDefault()
+	ff := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2))
+	ret["float"] = ff.GetFeature().GetTree().GetDefault()
+	jf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1.0, 2.0})
+	ret["json"] = jf.GetFeature().GetTree().GetDefault()
+	pf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58))
+	ret["proto"] = pf.GetFeature().GetTree().GetDefault()
+	return ret
+}
+
+func TestInMemoryProviderSuccess(t *testing.T) {
+	im := &inMemoryProvider{
+		store: &testStore{
+			configs: makeConfigs(),
+		},
+	}
+	ctx := context.Background()
+	// happy paths
+	br, err := im.GetBoolFeature(ctx, "bool", "")
+	require.NoError(t, err)
+	assert.True(t, br)
+	sr, err := im.GetStringFeature(ctx, "string", "")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", sr)
+	ir, err := im.GetIntFeature(ctx, "int", "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), ir)
+	fr, err := im.GetFloatFeature(ctx, "float", "")
+	require.NoError(t, err)
+	assert.Equal(t, float64(1.2), fr)
+	var result []any
+	err = im.GetJSONFeature(ctx, "json", "", &result)
+	require.NoError(t, err)
+	assert.EqualValues(t, []any{1.0, 2.0}, result)
+	protoResult := &wrapperspb.Int32Value{}
+	err = im.GetProtoFeature(ctx, "proto", "", protoResult)
+	require.NoError(t, err)
+	assert.EqualValues(t, int32(58), protoResult.Value)
+	require.NoError(t, im.Close(ctx), "no error during close")
+}
+
+func TestInMemoryProviderTypeMismatch(t *testing.T) {
+	im := &inMemoryProvider{
+		store: &testStore{
+			configs: makeConfigs(),
+		},
+	}
+	ctx := context.Background()
+	_, err := im.GetStringFeature(ctx, "bool", "")
+	require.Error(t, err)
+	_, err = im.GetIntFeature(ctx, "bool", "")
+	require.Error(t, err)
+	_, err = im.GetFloatFeature(ctx, "bool", "")
+	require.Error(t, err)
+	var result bool
+	err = im.GetJSONFeature(ctx, "bool", "", &result)
+	require.Error(t, err)
+	protoResult := &wrapperspb.FloatValue{}
+	err = im.GetProtoFeature(ctx, "bool", "", protoResult)
+	require.Error(t, err)
+	require.NoError(t, im.Close(ctx), "no error during close")
+}
+
+func TestInMemoryProviderMissingFeature(t *testing.T) {
+	im := &inMemoryProvider{
+		store: &testStore{
+			configs: makeConfigs(),
+		},
+	}
+	ctx := context.Background()
+	_, err := im.GetBoolFeature(ctx, "missing", "")
+	require.Error(t, err)
+	require.NoError(t, im.Close(ctx), "no error during close")
+}
+
+func TestInMemoryProviderCloseError(t *testing.T) {
+	im := &inMemoryProvider{
+		store: &testStore{
+			configs:  makeConfigs(),
+			closeErr: errors.Errorf("close error"),
+		},
+	}
+	ctx := context.Background()
+	require.Error(t, im.Close(ctx), "error during close")
+}
+
+type testStore struct {
+	configs  map[string]*anypb.Any
+	closeErr error
+}
+
+func (ts *testStore) Evaluate(key string, namespace string, lc map[string]interface{}, dest proto.Message) error {
+	a, ok := ts.configs[key]
+	if !ok {
+		return errors.Errorf("key %s not found", key)
+	}
+	return a.UnmarshalTo(dest)
+}
+
+func (ts *testStore) Close(ctx context.Context) error {
+	return ts.closeErr
+}

--- a/client/in_memory_provider_test.go
+++ b/client/in_memory_provider_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
-	"github.com/lekkodev/go-sdk/internal/fixtures"
+	"github.com/lekkodev/go-sdk/testdata"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,17 +30,17 @@ import (
 
 func makeConfigs() map[string]*anypb.Any {
 	ret := make(map[string]*anypb.Any)
-	bf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true)
+	bf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true)
 	ret["bool"] = bf.GetFeature().GetTree().GetDefault()
-	sf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo")
+	sf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo")
 	ret["string"] = sf.GetFeature().GetTree().GetDefault()
-	intf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42))
+	intf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42))
 	ret["int"] = intf.GetFeature().GetTree().GetDefault()
-	ff := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2))
+	ff := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2))
 	ret["float"] = ff.GetFeature().GetTree().GetDefault()
-	jf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1.0, 2.0})
+	jf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1.0, 2.0})
 	ret["json"] = jf.GetFeature().GetTree().GetDefault()
-	pf := fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58))
+	pf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58))
 	ret["proto"] = pf.GetFeature().GetTree().GetDefault()
 	return ret
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1
 	buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.31.0-20230713234042-fbaaf4924427.1
 	buf.build/gen/go/lekkodev/sdk/bufbuild/connect-go v1.9.0-20230620172853-31a82baf7ccf.1
 	buf.build/gen/go/lekkodev/sdk/protocolbuffers/go v1.31.0-20230620172853-31a82baf7ccf.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1 h1:wIvg7wHKvJxchqJM+/RpewjWF4lu0E9z/VU/JqAi7WE=
+buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1/go.mod h1:siogXpHg2bbsZpEHT0ja4k6jthLmVbD9wfAW3iEHd28=
 buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.31.0-20230713234042-fbaaf4924427.1 h1:8bIAAqZ1ZMIoCgjxByLjNp+a5dZ7cGUPOe9Gavq+tpE=
 buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.31.0-20230713234042-fbaaf4924427.1/go.mod h1:mYcnts9MJhUckfRD5/qOThXC7Kaj7O714LOw5GoGZ9c=
 buf.build/gen/go/lekkodev/sdk/bufbuild/connect-go v1.9.0-20230620172853-31a82baf7ccf.1 h1:oTeZ9Ql9IiPpUiLy8PVWDdEjAbDs0KcKmvBKbgOCToY=

--- a/internal/fixtures/fixtures.go
+++ b/internal/fixtures/fixtures.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixtures
+
+import (
+	"strings"
+
+	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
+	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func valToAny(featureType featurev1beta1.FeatureType, v any) *anypb.Any {
+	var err error
+	dest := &anypb.Any{}
+	switch featureType {
+	case featurev1beta1.FeatureType_FEATURE_TYPE_BOOL:
+		tv, ok := v.(bool)
+		if !ok {
+			panic("invalid type")
+		}
+		w := &wrapperspb.BoolValue{Value: tv}
+		err = anypb.MarshalFrom(dest, w, proto.MarshalOptions{})
+	case featurev1beta1.FeatureType_FEATURE_TYPE_STRING:
+		tv, ok := v.(string)
+		if !ok {
+			panic("invalid type")
+		}
+		w := &wrapperspb.StringValue{Value: tv}
+		err = anypb.MarshalFrom(dest, w, proto.MarshalOptions{})
+	case featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT:
+		tv, ok := v.(float64)
+		if !ok {
+			panic("invalid type")
+		}
+		w := &wrapperspb.DoubleValue{Value: tv}
+		err = anypb.MarshalFrom(dest, w, proto.MarshalOptions{})
+	case featurev1beta1.FeatureType_FEATURE_TYPE_INT:
+		tv, ok := v.(int64)
+		if !ok {
+			panic("invalid type")
+		}
+		w := &wrapperspb.Int64Value{Value: tv}
+		err = anypb.MarshalFrom(dest, w, proto.MarshalOptions{})
+	case featurev1beta1.FeatureType_FEATURE_TYPE_PROTO:
+		pv, ok := v.(proto.Message)
+		if !ok {
+			panic("invalid type")
+		}
+		err = anypb.MarshalFrom(dest, pv, proto.MarshalOptions{})
+	case featurev1beta1.FeatureType_FEATURE_TYPE_JSON:
+		sv, structErr := structpb.NewValue(v)
+		if structErr != nil {
+			panic(err)
+		}
+		err = anypb.MarshalFrom(dest, sv, proto.MarshalOptions{})
+	default:
+		err = errors.Errorf("unknown feature type %v", featureType)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return dest
+}
+
+func Feature(ft featurev1beta1.FeatureType, value any) *backendv1beta1.Feature {
+	a := valToAny(ft, value)
+	parts := strings.Split(ft.String(), "_")
+	name := strings.ToLower(parts[len(parts)-1])
+	return &backendv1beta1.Feature{
+		Name: name,
+		Sha:  name,
+		Feature: &featurev1beta1.Feature{
+			Key: name,
+			Tree: &featurev1beta1.Tree{
+				Default: a,
+			},
+			Type: ft,
+		},
+	}
+}

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -1,0 +1,182 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"buf.build/gen/go/lekkodev/cli/bufbuild/connect-go/lekko/backend/v1beta1/backendv1beta1connect"
+	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
+	"github.com/bufbuild/connect-go"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	lekkoAPIKeyHeader = "apikey"
+)
+
+type Store interface {
+	Evaluate(key string, namespace string, lc map[string]interface{}, dest proto.Message) error
+	Close(ctx context.Context) error
+}
+
+// Constructs an in-memory store that fetches configs from lekko's backend.
+func NewBackendStore(ctx context.Context, apikey, url, ownerName, repoName string, updateInterval time.Duration) (Store, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	b := &BackendStore{
+		distClient: backendv1beta1connect.NewDistributionServiceClient(http.DefaultClient, url),
+		store:      newStore(),
+		repoKey: &backendv1beta1.RepositoryKey{
+			OwnerName: ownerName,
+			RepoName:  repoName,
+		},
+		apikey:         apikey,
+		updateInterval: updateInterval,
+		cancel:         cancel,
+	}
+	if err := b.registerWithBackoff(ctx); err != nil {
+		return nil, errors.Wrap(err, "error registering client")
+	}
+	if _, err := b.updateStoreWithBackoff(ctx); err != nil {
+		return nil, err
+	}
+	b.loop(ctx)
+	return b, nil
+}
+
+type BackendStore struct {
+	distClient         backendv1beta1connect.DistributionServiceClient
+	store              *store
+	repoKey            *backendv1beta1.RepositoryKey
+	apikey, sessionKey string
+	wg                 sync.WaitGroup
+	updateInterval     time.Duration
+	cancel             context.CancelFunc
+}
+
+// Close implements Store.
+func (b *BackendStore) Close(ctx context.Context) error {
+	// cancel any ongoing background loops
+	b.cancel()
+	// wait for background work to complete
+	b.wg.Wait()
+	_, err := b.distClient.DeregisterClient(ctx, connect.NewRequest(&backendv1beta1.DeregisterClientRequest{
+		SessionKey: b.sessionKey,
+	}))
+	return err
+}
+
+// Evaluate implements Store.
+func (b *BackendStore) Evaluate(key string, namespace string, lc map[string]interface{}, dest protoreflect.ProtoMessage) error {
+	return b.store.evaluateType(key, namespace, lc, dest)
+}
+
+func (b *BackendStore) registerWithBackoff(ctx context.Context) error {
+	req := connect.NewRequest(&backendv1beta1.RegisterClientRequest{
+		RepoKey:       b.repoKey,
+		NamespaceList: []string{}, // register all namespaces
+	})
+	req.Header().Set(lekkoAPIKeyHeader, b.apikey)
+	var resp *connect.Response[backendv1beta1.RegisterClientResponse]
+	var err error
+	op := func() error {
+		resp, err = b.distClient.RegisterClient(ctx, req)
+		return err
+	}
+
+	exp := backoff.NewExponentialBackOff()
+	exp.MaxElapsedTime = 10 * time.Second
+	if err := backoff.Retry(op, exp); err != nil {
+		return err
+	}
+	if resp != nil {
+		b.sessionKey = resp.Msg.GetSessionKey()
+	}
+	return nil
+}
+
+func (b *BackendStore) updateStoreWithBackoff(ctx context.Context) (bool, error) {
+	req := connect.NewRequest(&backendv1beta1.GetRepositoryContentsRequest{
+		RepoKey:    b.repoKey,
+		SessionKey: b.sessionKey,
+	})
+	req.Header().Set(lekkoAPIKeyHeader, b.apikey)
+	var contents *backendv1beta1.GetRepositoryContentsResponse
+	op := func() error {
+		resp, err := b.distClient.GetRepositoryContents(ctx, req)
+		if err != nil {
+			return errors.Wrap(err, "get repository contents from backend")
+		}
+		contents = resp.Msg
+		return nil
+	}
+	exp := backoff.NewExponentialBackOff()
+	exp.MaxElapsedTime = 10 * time.Second
+	if err := backoff.Retry(op, exp); err != nil {
+		return false, err
+	}
+	updated := b.store.update(contents)
+	return updated, nil
+}
+
+func (b *BackendStore) shouldUpdateStore(ctx context.Context) (bool, error) {
+	req := connect.NewRequest(&backendv1beta1.GetRepositoryVersionRequest{
+		RepoKey:    b.repoKey,
+		SessionKey: b.sessionKey,
+	})
+	req.Header().Set(lekkoAPIKeyHeader, b.apikey)
+	resp, err := b.distClient.GetRepositoryVersion(ctx, req)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get repository version")
+	}
+	should := b.store.shouldUpdate(resp.Msg.GetCommitSha())
+	return should, nil
+}
+
+func (b *BackendStore) loop(ctx context.Context) {
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		after := time.After(b.updateInterval)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-after:
+				after = time.After(b.updateInterval)
+				should, err := b.shouldUpdateStore(ctx)
+				if err != nil {
+					log.Printf("failed to compare repo version: %v", err)
+					continue
+				}
+				if !should {
+					continue
+				}
+				_, err = b.updateStoreWithBackoff(ctx)
+				if err != nil {
+					log.Printf("failed to update store: %v", err)
+					continue
+				}
+			}
+		}
+	}()
+}

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -35,7 +35,7 @@ const (
 )
 
 type Store interface {
-	Evaluate(key string, namespace string, lc map[string]interface{}, dest proto.Message) error
+	Evaluate(key string, namespace string, lekkoContext map[string]interface{}, dest proto.Message) error
 	Close(ctx context.Context) error
 }
 
@@ -163,13 +163,12 @@ func (b *backendStore) loop(ctx context.Context) {
 	b.wg.Add(1)
 	go func() {
 		defer b.wg.Done()
-		after := time.After(b.updateInterval)
+		tick := time.NewTicker(b.updateInterval)
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-after:
-				after = time.After(b.updateInterval)
+			case <-tick.C:
 				should, err := b.shouldUpdateStore(ctx)
 				if err != nil {
 					log.Printf("failed to compare repo version: %v", err)

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -164,6 +164,7 @@ func (b *backendStore) loop(ctx context.Context) {
 	go func() {
 		defer b.wg.Done()
 		tick := time.NewTicker(b.updateInterval)
+		defer tick.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/internal/memory/backend_test.go
+++ b/internal/memory/backend_test.go
@@ -23,7 +23,7 @@ import (
 	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
 	connect "github.com/bufbuild/connect-go"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/lekkodev/go-sdk/internal/fixtures"
+	"github.com/lekkodev/go-sdk/testdata"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,12 +43,12 @@ func repositoryContents() *backendv1beta1.GetRepositoryContentsResponse {
 			{
 				Name: "ns-1",
 				Features: []*backendv1beta1.Feature{
-					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true),
-					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo"),
-					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2)),
-					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42)),
-					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1, 2.5, "bar"}),
-					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58)),
+					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true),
+					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo"),
+					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2)),
+					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42)),
+					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1, 2.5, "bar"}),
+					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58)),
 				},
 			},
 		},

--- a/internal/memory/backend_test.go
+++ b/internal/memory/backend_test.go
@@ -1,0 +1,158 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
+	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
+	connect "github.com/bufbuild/connect-go"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/lekkodev/go-sdk/internal/fixtures"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+const (
+	testSessionKey = "test-session"
+)
+
+func repositoryContents() *backendv1beta1.GetRepositoryContentsResponse {
+	return &backendv1beta1.GetRepositoryContentsResponse{
+		CommitSha: "commitsha",
+		Namespaces: []*backendv1beta1.Namespace{
+			{
+				Name: "ns-1",
+				Features: []*backendv1beta1.Feature{
+					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true),
+					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo"),
+					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2)),
+					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42)),
+					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1, 2.5, "bar"}),
+					fixtures.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58)),
+				},
+			},
+		},
+	}
+}
+
+func TestBackendStore(t *testing.T) {
+	tds := &testDistService{
+		sessionKey: testSessionKey,
+		contents:   repositoryContents(),
+	}
+	ctx := context.Background()
+	b, err := newBackendStore(ctx, "apikey", "owner", "repo", 5*time.Second, tds)
+	require.NoError(t, err, "no error during register and init")
+
+	bv := &wrapperspb.BoolValue{}
+	require.NoError(t, b.Evaluate("bool", "ns-1", nil, bv))
+	assert.Equal(t, true, bv.Value)
+	sv := &wrapperspb.StringValue{}
+	require.NoError(t, b.Evaluate("string", "ns-1", nil, sv))
+	assert.Equal(t, "foo", sv.Value)
+	iv := &wrapperspb.Int64Value{}
+	require.NoError(t, b.Evaluate("int", "ns-1", nil, iv))
+	assert.Equal(t, int64(42), iv.Value)
+	fv := &wrapperspb.DoubleValue{}
+	require.NoError(t, b.Evaluate("float", "ns-1", nil, fv))
+	assert.Equal(t, float64(1.2), fv.Value)
+	vv := &structpb.Value{}
+	require.NoError(t, b.Evaluate("json", "ns-1", nil, vv))
+	expectedValue, err := structpb.NewValue([]any{1, 2.5, "bar"})
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(expectedValue, vv))
+	pv := &wrapperspb.Int32Value{}
+	require.NoError(t, b.Evaluate("proto", "ns-1", nil, pv))
+	assert.Equal(t, int32(58), pv.Value)
+
+	require.NoError(t, b.Close(ctx), "no error during close")
+}
+
+func TestBackendStoreRegisterError(t *testing.T) {
+	tds := &testDistService{
+		sessionKey:  testSessionKey,
+		contents:    repositoryContents(),
+		registerErr: backoff.Permanent(errors.New("registration failed")),
+	}
+	ctx := context.Background()
+	_, err := newBackendStore(ctx, "apikey", "owner", "repo", 5*time.Second, tds)
+	require.Error(t, err)
+}
+
+func TestBackendStoreDeregisterError(t *testing.T) {
+	tds := &testDistService{
+		sessionKey:    testSessionKey,
+		contents:      repositoryContents(),
+		deregisterErr: errors.New("deregistration failed"),
+	}
+	ctx := context.Background()
+	b, err := newBackendStore(ctx, "apikey", "owner", "repo", 5*time.Second, tds)
+	require.NoError(t, err)
+
+	require.Error(t, b.Close(ctx))
+}
+
+func TestBackendStoreGetContentsError(t *testing.T) {
+	tds := &testDistService{
+		sessionKey:     testSessionKey,
+		contents:       repositoryContents(),
+		getContentsErr: backoff.Permanent(errors.New("get contents failed")),
+	}
+	ctx := context.Background()
+	_, err := newBackendStore(ctx, "apikey", "owner", "repo", 5*time.Second, tds)
+	require.Error(t, err)
+}
+
+type testDistService struct {
+	sessionKey                                                string
+	registerErr, deregisterErr, getContentsErr, getVersionErr error
+	contents                                                  *backendv1beta1.GetRepositoryContentsResponse
+}
+
+func (tds *testDistService) DeregisterClient(context.Context, *connect.Request[backendv1beta1.DeregisterClientRequest]) (*connect.Response[backendv1beta1.DeregisterClientResponse], error) {
+	return connect.NewResponse(&backendv1beta1.DeregisterClientResponse{}), tds.deregisterErr
+}
+
+func (*testDistService) GetDeveloperAccessToken(context.Context, *connect.Request[backendv1beta1.GetDeveloperAccessTokenRequest]) (*connect.Response[backendv1beta1.GetDeveloperAccessTokenResponse], error) {
+	return connect.NewResponse(&backendv1beta1.GetDeveloperAccessTokenResponse{}), nil
+}
+
+func (tds *testDistService) GetRepositoryContents(context.Context, *connect.Request[backendv1beta1.GetRepositoryContentsRequest]) (*connect.Response[backendv1beta1.GetRepositoryContentsResponse], error) {
+	return connect.NewResponse(tds.contents), tds.getContentsErr
+}
+
+func (tds *testDistService) GetRepositoryVersion(context.Context, *connect.Request[backendv1beta1.GetRepositoryVersionRequest]) (*connect.Response[backendv1beta1.GetRepositoryVersionResponse], error) {
+	return connect.NewResponse(&backendv1beta1.GetRepositoryVersionResponse{
+		CommitSha: tds.contents.GetCommitSha(),
+	}), tds.getVersionErr
+}
+
+func (tds *testDistService) RegisterClient(context.Context, *connect.Request[backendv1beta1.RegisterClientRequest]) (*connect.Response[backendv1beta1.RegisterClientResponse], error) {
+	return connect.NewResponse(&backendv1beta1.RegisterClientResponse{
+		SessionKey: tds.sessionKey,
+	}), tds.registerErr
+}
+
+func (*testDistService) SendFlagEvaluationMetrics(context.Context, *connect.Request[backendv1beta1.SendFlagEvaluationMetricsRequest]) (*connect.Response[backendv1beta1.SendFlagEvaluationMetricsResponse], error) {
+	panic("unimplemented")
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -30,7 +30,9 @@ var (
 )
 
 func newStore() *store {
-	return &store{}
+	return &store{
+		configs: make(map[configKey]configData),
+	}
 }
 
 type configKey struct {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1,0 +1,127 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"fmt"
+	"sync"
+
+	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
+	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
+	"github.com/lekkodev/go-sdk/pkg/eval"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	ErrConfigNotFound error = fmt.Errorf("config not found")
+)
+
+func newStore() *store {
+	return &store{}
+}
+
+type configKey struct {
+	namespace, config string
+}
+
+type configData struct {
+	config    *featurev1beta1.Feature
+	configSHA string
+}
+
+// store implements an in-memory store for configurations. It stores
+// the commit sha of the contents. It supports atomically updating
+// all the configs with the contents of a new commit via the Update method.
+type store struct {
+	sync.RWMutex
+	configs   map[configKey]configData
+	commitSHA string
+}
+
+type storedConfig struct {
+	Config               *featurev1beta1.Feature
+	CommitSHA, ConfigSHA string
+}
+
+func (s *store) update(contents *backendv1beta1.GetRepositoryContentsResponse) bool {
+	newConfigs := make(map[configKey]configData)
+	for _, ns := range contents.GetNamespaces() {
+		for _, cfg := range ns.GetFeatures() {
+			newConfigs[configKey{ns.GetName(), cfg.GetName()}] = configData{
+				config:    cfg.GetFeature(),
+				configSHA: cfg.GetSha(),
+			}
+		}
+	}
+	commitSHA := contents.GetCommitSha()
+	// preemptive check to avoid holding the write lock at the
+	// last minute if we can avoid it
+	if !s.shouldUpdate(commitSHA) {
+		return false
+	}
+	var updated bool
+	s.Lock()
+	if commitSHA != s.commitSHA {
+		s.configs = newConfigs
+		s.commitSHA = commitSHA
+		updated = true
+	}
+	s.Unlock()
+	return updated
+}
+
+func (s *store) get(namespace, key string) (*storedConfig, error) {
+	ck := configKey{namespace, key}
+	var data configData
+	var ok bool
+	var commitSHA string
+	s.RLock()
+	data, ok = s.configs[ck]
+	commitSHA = s.commitSHA
+	s.RUnlock()
+	if !ok {
+		return nil, ErrConfigNotFound
+	}
+	return &storedConfig{
+		Config:    data.config,
+		CommitSHA: commitSHA,
+		ConfigSHA: data.configSHA,
+	}, nil
+}
+
+func (s *store) shouldUpdate(newCommitSHA string) bool {
+	var shouldUpdate bool
+	s.RLock()
+	shouldUpdate = newCommitSHA != s.commitSHA
+	s.RUnlock()
+	return shouldUpdate
+}
+
+func (s *store) evaluateType(key string, namespace string, lc map[string]interface{}, dest proto.Message) error {
+	cfg, err := s.get(namespace, key)
+	if err != nil {
+		return err
+	}
+	evaluableConfig := eval.NewV1Beta3(cfg.Config, namespace)
+	a, _, err := evaluableConfig.Evaluate(lc)
+	if err != nil {
+		return err
+	}
+	if err := a.UnmarshalTo(dest); err != nil {
+		return errors.Wrapf(err, "invalid type, expecting %T", dest)
+	}
+	return nil
+}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"fmt"
+	"testing"
+)
+
+type configKey struct {
+	namespace, config string
+}
+
+func BenchmarkMapKeyAccess(b *testing.B) {
+	type benchmarkData struct {
+		namespaceName string
+		configName    string
+	}
+	var data []benchmarkData
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 100; j++ {
+			data = append(data, benchmarkData{namespaceName: fmt.Sprint(i), configName: fmt.Sprint(j)})
+		}
+	}
+
+	structMap := make(map[configKey]configData)
+	for _, d := range data {
+		structMap[configKey{
+			namespace: d.namespaceName,
+			config:    d.configName,
+		}] = configData{}
+	}
+
+	mapMap := make(map[string]map[string]configData)
+	for _, d := range data {
+		// see if ns exists
+		_, ok := mapMap[d.namespaceName]
+		if !ok {
+			mapMap[d.namespaceName] = make(map[string]configData)
+		}
+		mapMap[d.namespaceName][d.configName] = configData{}
+	}
+
+	b.Run("struct map access", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, d := range data {
+				_ = structMap[configKey{
+					namespace: d.namespaceName,
+					config:    d.configName,
+				}]
+			}
+		}
+	})
+
+	b.Run("map map access", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, d := range data {
+				_ = mapMap[d.namespaceName][d.configName]
+			}
+		}
+	})
+}

--- a/make/example/all.mk
+++ b/make/example/all.mk
@@ -1,6 +1,6 @@
 GO_BINS := $(GO_BINS) cmd/example
 DOCKER_BINS := $(DOCKER_BINS) example
-GO_ALL_REPO_PKGS := $(GO_ALL_REPO_PKGS) ./client/... ./pkg/...
+GO_ALL_REPO_PKGS := $(GO_ALL_REPO_PKGS) ./client/... ./pkg/... ./internal/...
 GOPRIVATE := $(GOPRIVATE),github.com/lekkodev/*
 # DOCKER_BUILD_EXTRA_FLAGS := --platform=linux/amd64
 

--- a/testdata/fixtures.go
+++ b/testdata/fixtures.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fixtures
+package testdata
 
 import (
 	"strings"


### PR DESCRIPTION
- New backend in-memory provider with example usage code
- interfaced `Store` concept to be shared for local mode in the future

Next:
- Send batched flag-evaluation metrics
- Local mode