### PR TITLE
sha256 configs to optimize local hot-reloads

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -34,7 +34,7 @@ func main() {
 	flag.Parse()
 
 	var provider client.Provider
-	if mode != "static" && key == "" {
+	if mode != "gitlocal" && key == "" {
 		log.Fatal("Lekko API key not provided. Exiting...")
 	}
 	var err error

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -163,8 +163,7 @@ func (b *backendStore) updateStoreWithBackoff(ctx context.Context) (bool, error)
 	if err := backoff.Retry(op, exp); err != nil {
 		return false, err
 	}
-	updated := b.store.update(contents)
-	return updated, nil
+	return b.store.update(contents)
 }
 
 func (b *backendStore) shouldUpdateStore(ctx context.Context) (bool, error) {
@@ -177,8 +176,7 @@ func (b *backendStore) shouldUpdateStore(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get repository version")
 	}
-	should := b.store.shouldUpdate(resp.Msg.GetCommitSha())
-	return should, nil
+	return b.store.getCommitSha() != resp.Msg.GetCommitSha(), nil
 }
 
 func (b *backendStore) loop(ctx context.Context) {

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -140,7 +140,7 @@ func (g *gitStore) load(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return g.store.update(contents), nil
+	return g.store.update(contents)
 }
 
 func (g *gitStore) startWatcher(ctx context.Context) error {

--- a/internal/memory/repo.go
+++ b/internal/memory/repo.go
@@ -71,20 +71,7 @@ func (r *repository) getCommitSha() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	baseSHA := ref.Hash().String()
-	wt, err := r.Worktree()
-	if err != nil {
-		return "", err
-	}
-	status, err := wt.Status()
-	if err != nil {
-		return "", err
-	}
-	var suffix string
-	if !status.IsClean() {
-		suffix = "-dirty"
-	}
-	return fmt.Sprintf("%s%s", baseSHA, suffix), nil
+	return ref.Hash().String(), nil
 }
 
 type RootConfigRepoMetadata struct {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -100,7 +100,7 @@ func (s *store) update(contents *backendv1beta1.GetRepositoryContentsResponse) (
 	if !ok {
 		return false, nil
 	}
-	if err := req.hash(); err != nil {
+	if err := req.calculateContentHash(); err != nil {
 		return false, err
 	}
 	s.configs = newConfigs
@@ -137,7 +137,7 @@ func (s *store) shouldUpdateUnsafe(req *updateRequest) (bool, error) {
 	if req.contents.GetCommitSha() != s.commitSHA {
 		return true, nil
 	}
-	if err := req.hash(); err != nil {
+	if err := req.calculateContentHash(); err != nil {
 		return false, err
 	}
 	return *req.contentHash != s.contentHash, nil
@@ -174,7 +174,7 @@ type updateRequest struct {
 	contentHash *string
 }
 
-func (ur *updateRequest) hash() error {
+func (ur *updateRequest) calculateContentHash() error {
 	if ur.contentHash != nil {
 		return nil
 	}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -182,8 +182,12 @@ func (ur *updateRequest) hash() error {
 	if err != nil {
 		return err
 	}
-	shaBytes := sha256.Sum256(bytes)
-	sha := hex.EncodeToString(shaBytes[:])
+	sha := hashContentsSHA256(bytes)
 	ur.contentHash = &sha
 	return nil
+}
+
+func hashContentsSHA256(bytes []byte) string {
+	shaBytes := sha256.Sum256(bytes)
+	return hex.EncodeToString(shaBytes[:])
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -27,7 +27,7 @@ func TestHashUpdateRequest(t *testing.T) {
 	req := &updateRequest{
 		contents: testdata.RepositoryContents(),
 	}
-	require.NoError(t, req.hash())
+	require.NoError(t, req.calculateContentHash())
 	require.NotNil(t, req.contentHash)
 	expected := *req.contentHash
 	bytes, err := proto.MarshalOptions{Deterministic: true}.Marshal(req.contents)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -17,7 +17,28 @@ package memory
 import (
 	"fmt"
 	"testing"
+
+	"github.com/lekkodev/go-sdk/testdata"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
+
+func TestHashUpdateRequest(t *testing.T) {
+	req := &updateRequest{
+		contents: testdata.RepositoryContents(),
+	}
+	require.NoError(t, req.hash())
+	require.NotNil(t, req.contentHash)
+	expected := *req.contentHash
+	bytes, err := proto.MarshalOptions{Deterministic: true}.Marshal(req.contents)
+	require.NoError(t, err)
+	// test the determinism of the hash
+	for i := 0; i < 10; i++ {
+		require.Equal(t, expected, hashContentsSHA256(bytes))
+	}
+}
+
+// Benchmarks
 
 type configKey struct {
 	namespace, config string

--- a/testdata/fixtures.go
+++ b/testdata/fixtures.go
@@ -15,6 +15,7 @@
 package testdata
 
 import (
+	"fmt"
 	"strings"
 
 	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
@@ -93,5 +94,36 @@ func Feature(ft featurev1beta1.FeatureType, value any) *backendv1beta1.Feature {
 			},
 			Type: ft,
 		},
+	}
+}
+
+func Namespace(name string) *backendv1beta1.Namespace {
+	return &backendv1beta1.Namespace{
+		Name: name,
+		Features: []*backendv1beta1.Feature{
+			{
+				Name: "example",
+				Sha:  "e5a024dd8bf777c3a23ccf1da21fa29aebc5bf28",
+				Feature: &featurev1beta1.Feature{
+					Key:         "example",
+					Description: "an example configuration",
+					Tree: &featurev1beta1.Tree{
+						Default: ValToAny(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true),
+					},
+					Type: featurev1beta1.FeatureType_FEATURE_TYPE_BOOL,
+				},
+			},
+		},
+	}
+}
+
+func RepositoryContents() *backendv1beta1.GetRepositoryContentsResponse {
+	var namespaces []*backendv1beta1.Namespace
+	for i := 0; i < 200; i++ {
+		namespaces = append(namespaces, Namespace(fmt.Sprintf("%d", i)))
+	}
+	return &backendv1beta1.GetRepositoryContentsResponse{
+		CommitSha:  "0a06da7c1c4a37bed9ff974009265da5196e81ca",
+		Namespaces: namespaces,
 	}
 }


### PR DESCRIPTION
Previously, we were only relying on git commit hash to determine whether or not to reload the 
store. And whenever git determined that the working tree was dirty, we would always reload. This 
had two problems:
1. We have a dependency on checking the status of the git work tree, which may not be easy in 
every language
2. hot reloads in git-local mode are very expensive. Every keystroke in an editor that autosaves 
would result in a hot-reload, even if your materialized view didn't change (i.e. you didn't run 
lekko compile).

This change computes a sha256 of the contents to determine if we should perform the reload.
