### PR TITLE
add http option for tiered distro

### DIFF
--- a/client/api_provider.go
+++ b/client/api_provider.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	defaultAPIURL     = "https://prod.api.lekko.dev:443"
-	defaultSidecarURL = "https://localhost:50051"
+	defaultSidecarURL = "http://localhost:50051"
 	lekkoAPIKeyHeader = "apikey"
 )
 

--- a/client/cached_provider.go
+++ b/client/cached_provider.go
@@ -47,10 +47,12 @@ func CachedAPIProvider(
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
+
 	backend, err := memory.NewBackendStore(
 		ctx,
 		cfg.apiKey, cfg.url,
 		cfg.repoKey.OwnerName, cfg.repoKey.RepoName,
+		cfg.allowHTTP,
 		cfg.updateInterval, cfg.serverPort)
 	if err != nil {
 		return nil, err

--- a/client/cached_provider.go
+++ b/client/cached_provider.go
@@ -52,7 +52,7 @@ func CachedAPIProvider(
 		ctx,
 		cfg.apiKey, cfg.url,
 		cfg.repoKey.OwnerName, cfg.repoKey.RepoName,
-		cfg.allowHTTP,
+		cfg.getHTTPClient(),
 		cfg.updateInterval, cfg.serverPort)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func CachedGitFsProvider(
 		ctx,
 		cfg.apiKey, cfg.url,
 		cfg.repoKey.OwnerName, cfg.repoKey.RepoName,
-		path, cfg.serverPort,
+		path, cfg.getHTTPClient(), cfg.serverPort,
 	)
 	if err != nil {
 		return nil, err

--- a/client/provider.go
+++ b/client/provider.go
@@ -125,6 +125,9 @@ func (cfg *providerConfig) validate() error {
 	} else if cfg.updateInterval.Seconds() < minUpdateInterval.Seconds() {
 		return errors.Errorf("update interval too small, minimum %v", minUpdateInterval)
 	}
+	if cfg.allowHTTP && strings.HasPrefix(cfg.url, "https://") {
+		return errors.Errorf("connecting to https endpoint: %s over gRPC/h2c, please unset AllowHTTP option", cfg.url)
+	}
 	if !cfg.allowHTTP && strings.HasPrefix(cfg.url, "http://") {
 		return errors.Errorf("connecting to http endpoint: %s over gRPC/TLS, please set AllowHTTP option", cfg.url)
 	}

--- a/client/provider.go
+++ b/client/provider.go
@@ -125,9 +125,7 @@ func (cfg *providerConfig) validate() error {
 	} else if cfg.updateInterval.Seconds() < minUpdateInterval.Seconds() {
 		return errors.Errorf("update interval too small, minimum %v", minUpdateInterval)
 	}
-	if cfg.allowHTTP && strings.HasPrefix(cfg.url, "https://") {
-		return errors.Errorf("connecting to https endpoint: %s over gRPC/h2c, please unset AllowHTTP option", cfg.url)
-	} else if !cfg.allowHTTP && strings.HasPrefix(cfg.url, "http://") {
+	if !cfg.allowHTTP && strings.HasPrefix(cfg.url, "http://") {
 		return errors.Errorf("connecting to http endpoint: %s over gRPC/TLS, please set AllowHTTP option", cfg.url)
 	}
 	return nil

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -16,10 +16,8 @@ package memory
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -29,7 +27,6 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
-	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -48,21 +45,10 @@ type Store interface {
 func NewBackendStore(
 	ctx context.Context,
 	apiKey, url, ownerName, repoName string,
-	allowHTTP bool,
+	client *http.Client,
 	updateInterval time.Duration,
 	serverPort int32,
 ) (Store, error) {
-	client := http.DefaultClient
-	if allowHTTP {
-		client = &http.Client{
-			Transport: &http2.Transport{
-				AllowHTTP: true,
-				DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-					return net.Dial(network, addr)
-				},
-			},
-		}
-	}
 	return newBackendStore(
 		ctx,
 		apiKey, ownerName, repoName,

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -49,11 +48,12 @@ type Store interface {
 func NewBackendStore(
 	ctx context.Context,
 	apiKey, url, ownerName, repoName string,
+	allowHTTP bool,
 	updateInterval time.Duration,
 	serverPort int32,
 ) (Store, error) {
 	client := http.DefaultClient
-	if strings.HasPrefix(url, "http://") {
+	if allowHTTP {
 		client = &http.Client{
 			Transport: &http2.Transport{
 				AllowHTTP: true,

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -119,7 +119,7 @@ func (b *backendStore) Close(ctx context.Context) error {
 	req := connect.NewRequest(&backendv1beta1.DeregisterClientRequest{
 		SessionKey: b.sessionKey,
 	})
-	req.Header().Set(lekkoAPIKeyHeader, b.apiKey)
+	setAPIKey(req, b.apiKey)
 	_, err := b.distClient.DeregisterClient(ctx, req)
 	return err
 }
@@ -148,7 +148,7 @@ func (b *backendStore) registerWithBackoff(ctx context.Context) (string, error) 
 		RepoKey:       b.repoKey,
 		NamespaceList: []string{}, // register all namespaces
 	})
-	req.Header().Set(lekkoAPIKeyHeader, b.apiKey)
+	setAPIKey(req, b.apiKey)
 	var resp *connect.Response[backendv1beta1.RegisterClientResponse]
 	var err error
 	op := func() error {
@@ -173,7 +173,7 @@ func (b *backendStore) updateStoreWithBackoff(ctx context.Context) (bool, error)
 		RepoKey:    b.repoKey,
 		SessionKey: b.sessionKey,
 	})
-	req.Header().Set(lekkoAPIKeyHeader, b.apiKey)
+	setAPIKey(req, b.apiKey)
 	var contents *backendv1beta1.GetRepositoryContentsResponse
 	op := func() error {
 		resp, err := b.distClient.GetRepositoryContents(ctx, req)
@@ -196,7 +196,7 @@ func (b *backendStore) shouldUpdateStore(ctx context.Context) (bool, error) {
 		RepoKey:    b.repoKey,
 		SessionKey: b.sessionKey,
 	})
-	req.Header().Set(lekkoAPIKeyHeader, b.apiKey)
+	setAPIKey(req, b.apiKey)
 	resp, err := b.distClient.GetRepositoryVersion(ctx, req)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get repository version")
@@ -285,4 +285,10 @@ func toResultPathProto(rp []int) []int32 {
 		ret[i] = int32(rp[i])
 	}
 	return ret
+}
+
+func setAPIKey(req connect.AnyRequest, apiKey string) {
+	if len(apiKey) > 0 {
+		req.Header().Set(lekkoAPIKeyHeader, apiKey)
+	}
 }

--- a/internal/memory/events.go
+++ b/internal/memory/events.go
@@ -115,7 +115,7 @@ func (e *eventBatcher) sendBatchWithBackoff(ctx context.Context, batch []*backen
 		Events:     batch,
 		SessionKey: e.sessionKey,
 	})
-	req.Header().Set(lekkoAPIKeyHeader, e.apiKey)
+	setAPIKey(req, e.apiKey)
 	op := func() error {
 		_, err := e.distClient.SendFlagEvaluationMetrics(ctx, req)
 		if err != nil {

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -124,7 +124,7 @@ func (g *gitStore) registerWithBackoff(ctx context.Context) (string, error) {
 		RepoKey:       g.repoKey,
 		NamespaceList: []string{}, // register all namespaces
 	})
-	req.Header().Set(lekkoAPIKeyHeader, g.apiKey)
+	setAPIKey(req, g.apiKey)
 	var resp *connect.Response[backendv1beta1.RegisterClientResponse]
 	var err error
 	op := func() error {
@@ -216,7 +216,7 @@ func (g *gitStore) Close(ctx context.Context) error {
 		req := connect.NewRequest(&backendv1beta1.DeregisterClientRequest{
 			SessionKey: g.sessionKey,
 		})
-		req.Header().Set(lekkoAPIKeyHeader, g.apiKey)
+		setAPIKey(req, g.apiKey)
 		if _, err := g.distClient.DeregisterClient(ctx, req); err != nil {
 			log.Printf("error deregistering lekko client: %v", err)
 		}

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -41,11 +41,12 @@ import (
 func NewGitStore(
 	ctx context.Context,
 	apiKey, url, ownerName, repoName, path string,
+	client *http.Client,
 	port int32,
 ) (Store, error) {
 	var distClient backendv1beta1connect.DistributionServiceClient
 	if len(apiKey) > 0 {
-		distClient = backendv1beta1connect.NewDistributionServiceClient(http.DefaultClient, url)
+		distClient = backendv1beta1connect.NewDistributionServiceClient(client, url, connect.WithGRPC())
 	}
 	fs := osfs.New(path)
 	gitfs, err := fs.Chroot(git.GitDirName)


### PR DESCRIPTION
in order to test tiered distribution with the sidecar, run the sidecar in a docker container:
```bash
docker run \
    --rm --name sidecar \
    -p 50051:50051 -d \
    -v $HOME/example:/root/example \
    525250420071.dkr.ecr.us-east-1.amazonaws.com/lekko/sidecar:2ed1c838c617376929c1fbc76afc0d662a94ecf2 \
    --repo-path=/root/example --mode=static
```


then run the example script:
```bash
go run cmd/example/main.go \
    --lekko-apikey=$LEKKO_API_KEY \
    --mode cached --url https://localhost:50051 --allow-http
```