### PR TITLE
Short-lived contexts

### DIFF
--- a/client/api_provider.go
+++ b/client/api_provider.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	clientv1beta1connect "buf.build/gen/go/lekkodev/sdk/bufbuild/connect-go/lekko/client/v1beta1/clientv1beta1connect"
 	clientv1beta1 "buf.build/gen/go/lekkodev/sdk/protocolbuffers/go/lekko/client/v1beta1"
@@ -44,7 +45,8 @@ func ConnectAPIProvider(ctx context.Context, apiKey string, rk *RepositoryKey, o
 	withFallbackURL(defaultAPIURL).apply(cfg)
 	WithAPIKey(apiKey).apply(cfg)
 	withRepositoryKey(rk).apply(cfg)
-	if err := cfg.validate(); err != nil {
+	WithAllowShortLived().apply(cfg) // don't need a long-lived context
+	if err := cfg.validate(ctx); err != nil {
 		return nil, err
 	}
 	provider := &apiProvider{
@@ -71,8 +73,9 @@ func ConnectSidecarProvider(ctx context.Context, url string, rk *RepositoryKey, 
 	WithURL(url).apply(cfg)
 	withFallbackURL(defaultSidecarURL).apply(cfg)
 	withRepositoryKey(rk).apply(cfg)
-	WithAllowHTTP().apply(cfg) // sidecar must communicate over h2c
-	if err := cfg.validate(); err != nil {
+	WithAllowHTTP().apply(cfg)       // sidecar must communicate over h2c
+	WithAllowShortLived().apply(cfg) // don't need a long-lived context
+	if err := cfg.validate(ctx); err != nil {
 		return nil, err
 	}
 	// The sidecar exposes the same interface as the backend API, so we can transparently
@@ -121,6 +124,9 @@ type apiProvider struct {
 // This performs an exponential backoff until the context is cancelled.
 // We do this to try to alleviate some issues with sidecars starting up.
 func (a *apiProvider) registerWithBackoff(ctx context.Context) error {
+	// registration should not take forever
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	req := connect.NewRequest(&clientv1beta1.RegisterRequest{RepoKey: a.rk.toProto()})
 	req.Header().Set(lekkoAPIKeyHeader, a.apikey)
 	ticker := backoff.NewTicker(backoff.NewExponentialBackOff())

--- a/client/api_provider.go
+++ b/client/api_provider.go
@@ -33,6 +33,9 @@ const (
 	defaultAPIURL     = "https://prod.api.lekko.dev:443"
 	defaultSidecarURL = "http://localhost:50051"
 	lekkoAPIKeyHeader = "apikey"
+	// The default ctx deadline set for registration
+	// and loading contents on startup.
+	defaultRPCDeadline = 3 * time.Second
 )
 
 // Fetches configuration directly from Lekko Backend APIs.
@@ -125,7 +128,7 @@ type apiProvider struct {
 // We do this to try to alleviate some issues with sidecars starting up.
 func (a *apiProvider) registerWithBackoff(ctx context.Context) error {
 	// registration should not take forever
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, defaultRPCDeadline)
 	defer cancel()
 	req := connect.NewRequest(&clientv1beta1.RegisterRequest{RepoKey: a.rk.toProto()})
 	req.Header().Set(lekkoAPIKeyHeader, a.apikey)

--- a/client/cached_provider.go
+++ b/client/cached_provider.go
@@ -44,7 +44,7 @@ func CachedAPIProvider(
 	}
 	withFallbackURL(defaultAPIURL).apply(cfg)
 	withRepositoryKey(rk).apply(cfg)
-	if err := cfg.validate(); err != nil {
+	if err := cfg.validate(ctx); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func CachedGitFsProvider(
 	if len(cfg.apiKey) > 0 {
 		withFallbackURL(defaultAPIURL).apply(cfg)
 	}
-	if err := cfg.validate(); err != nil {
+	if err := cfg.validate(ctx); err != nil {
 		return nil, err
 	}
 	gitStore, err := memory.NewGitStore(

--- a/client/provider.go
+++ b/client/provider.go
@@ -103,15 +103,29 @@ func WithServerOption(port int32) ProviderOption {
 
 func (o *ServerOption) apply(pc *providerConfig) { pc.serverPort = o.Port }
 
-type providerConfig struct {
-	repoKey        *RepositoryKey
-	apiKey, url    string
-	updateInterval time.Duration
-	serverPort     int32
-	allowHTTP      bool
+type AllowShortLivedOption struct{}
+
+// Allow instantiating the provider with a short-lived context.
+// Note that cached SDKs typically require an unbounded context,
+// because they continually fetch updates in the background.
+func WithAllowShortLived() ProviderOption {
+	return &AllowShortLivedOption{}
 }
 
-func (cfg *providerConfig) validate() error {
+func (o *AllowShortLivedOption) apply(cfg *providerConfig) {
+	cfg.allowShortLived = true
+}
+
+type providerConfig struct {
+	repoKey         *RepositoryKey
+	apiKey, url     string
+	updateInterval  time.Duration
+	serverPort      int32
+	allowHTTP       bool
+	allowShortLived bool
+}
+
+func (cfg *providerConfig) validate(ctx context.Context) error {
 	if cfg.repoKey == nil || len(cfg.repoKey.OwnerName) == 0 || len(cfg.repoKey.RepoName) == 0 {
 		return errors.New("missing repository key")
 	}
@@ -130,6 +144,11 @@ func (cfg *providerConfig) validate() error {
 	}
 	if !cfg.allowHTTP && strings.HasPrefix(cfg.url, "http://") {
 		return errors.Errorf("connecting to http endpoint: %s over gRPC/TLS, please set AllowHTTP option", cfg.url)
+	}
+	if !cfg.allowShortLived {
+		if _, hasDeadline := ctx.Deadline(); hasDeadline {
+			return errors.Errorf("context has a deadline, please use AllowShortLived option if this is intended")
+		}
 	}
 	return nil
 }

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -44,8 +44,7 @@ func main() {
 
 	var provider client.Provider
 	var err error
-	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancelF()
+	ctx := context.Background()
 	provider, err = getProvider(ctx, key, mode, path, owner, repo, url, port, allowHTTP)
 	if err != nil {
 		log.Fatalf("error when starting in %s mode: %v\n", mode, err)

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -145,6 +145,9 @@ func (b *backendStore) Evaluate(key string, namespace string, lc map[string]inte
 }
 
 func (b *backendStore) registerWithBackoff(ctx context.Context) (string, error) {
+	// registration should not take forever
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	req := connect.NewRequest(&backendv1beta1.RegisterClientRequest{
 		RepoKey:        b.repoKey,
 		NamespaceList:  []string{}, // register all namespaces
@@ -171,6 +174,8 @@ func (b *backendStore) registerWithBackoff(ctx context.Context) (string, error) 
 }
 
 func (b *backendStore) updateStoreWithBackoff(ctx context.Context) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	req := connect.NewRequest(&backendv1beta1.GetRepositoryContentsRequest{
 		RepoKey:    b.repoKey,
 		SessionKey: b.sessionKey,

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -35,6 +35,9 @@ const (
 	lekkoAPIKeyHeader = "apikey"
 	eventsBatchSize   = 100
 	sdkVersion        = "go" // the version we communicate to the server
+	// The default ctx deadline set for registration
+	// and loading contents on startup.
+	defaultRPCDeadline = 3 * time.Second
 )
 
 type Store interface {
@@ -146,7 +149,7 @@ func (b *backendStore) Evaluate(key string, namespace string, lc map[string]inte
 
 func (b *backendStore) registerWithBackoff(ctx context.Context) (string, error) {
 	// registration should not take forever
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, defaultRPCDeadline)
 	defer cancel()
 	req := connect.NewRequest(&backendv1beta1.RegisterClientRequest{
 		RepoKey:        b.repoKey,
@@ -174,7 +177,7 @@ func (b *backendStore) registerWithBackoff(ctx context.Context) (string, error) 
 }
 
 func (b *backendStore) updateStoreWithBackoff(ctx context.Context) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, defaultRPCDeadline)
 	defer cancel()
 	req := connect.NewRequest(&backendv1beta1.GetRepositoryContentsRequest{
 		RepoKey:    b.repoKey,

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -120,6 +120,9 @@ type gitStore struct {
 }
 
 func (g *gitStore) registerWithBackoff(ctx context.Context) (string, error) {
+	// registration should not take forever
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	req := connect.NewRequest(&backendv1beta1.RegisterClientRequest{
 		RepoKey:        g.repoKey,
 		NamespaceList:  []string{}, // register all namespaces

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -121,7 +121,7 @@ type gitStore struct {
 
 func (g *gitStore) registerWithBackoff(ctx context.Context) (string, error) {
 	// registration should not take forever
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, defaultRPCDeadline)
 	defer cancel()
 	req := connect.NewRequest(&backendv1beta1.RegisterClientRequest{
 		RepoKey:        g.repoKey,


### PR DESCRIPTION
- For cached SDKs, expect an unbounded context, to allow the client to indefinitely fetch updates 
in the background.
- Provide an `AllowShortLived` option to override this behavior.
- For regular Connect providers that don't update in the background, set `AllowShortLived` all 
the time because we don't have this requirement.

Also, the SDK now wraps its own startup code in tight contexts, so that we don't start up forever. we shouldn't rely on the caller to do that.
