### PR TITLE
Support multiple namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # go-sdk
-Golang SDK for reading feature flags
+Golang SDK for reading lekko configs
 
 ## Example
 
-This repo includes an example go program that retrieves a feature flag from Lekko backend. To test it, run
+This repo includes an example go program that retrieves a config from Lekko backend. To test it, run
 ```
 go run cmd/example/main.go --lekko-apikey=<replace-with-your-api-key>
 ```
-Make sure to replace the API key with the one given to your organization. Also, make sure to change the owner and repo name to a repository under your organization.
-Alternatively, you can build and run with docker, which may resemble how you might containerize your application and run it remotely. 
+Make sure to replace the API key with the one given to your organization. Also, change the owner and repo name to a repository under your organization.
+Alternatively, you can build and run with docker, which may resemble how you containerize your application and run it remotely.
 ```
 make dockerbuild
 ```

--- a/client/api_provider.go
+++ b/client/api_provider.go
@@ -170,7 +170,7 @@ func (a *apiProvider) Close(ctx context.Context) error {
 	return err
 }
 
-func (a *apiProvider) GetBoolFeature(ctx context.Context, key string, namespace string) (bool, error) {
+func (a *apiProvider) GetBool(ctx context.Context, key string, namespace string) (bool, error) {
 	lc, err := toProto(fromContext(ctx))
 	if err != nil {
 		return false, errors.Wrap(err, "error transforming context")
@@ -189,7 +189,7 @@ func (a *apiProvider) GetBoolFeature(ctx context.Context, key string, namespace 
 	return resp.Msg.GetValue(), nil
 }
 
-func (a *apiProvider) GetIntFeature(ctx context.Context, key string, namespace string) (int64, error) {
+func (a *apiProvider) GetInt(ctx context.Context, key string, namespace string) (int64, error) {
 	lc, err := toProto(fromContext(ctx))
 	if err != nil {
 		return 0, errors.Wrap(err, "error transforming context")
@@ -208,7 +208,7 @@ func (a *apiProvider) GetIntFeature(ctx context.Context, key string, namespace s
 	return resp.Msg.GetValue(), nil
 }
 
-func (a *apiProvider) GetFloatFeature(ctx context.Context, key string, namespace string) (float64, error) {
+func (a *apiProvider) GetFloat(ctx context.Context, key string, namespace string) (float64, error) {
 	lc, err := toProto(fromContext(ctx))
 	if err != nil {
 		return 0, errors.Wrap(err, "error transforming context")
@@ -227,7 +227,7 @@ func (a *apiProvider) GetFloatFeature(ctx context.Context, key string, namespace
 	return resp.Msg.GetValue(), nil
 }
 
-func (a *apiProvider) GetStringFeature(ctx context.Context, key string, namespace string) (string, error) {
+func (a *apiProvider) GetString(ctx context.Context, key string, namespace string) (string, error) {
 	lc, err := toProto(fromContext(ctx))
 	if err != nil {
 		return "", errors.Wrap(err, "error transforming context")
@@ -246,7 +246,7 @@ func (a *apiProvider) GetStringFeature(ctx context.Context, key string, namespac
 	return resp.Msg.GetValue(), nil
 }
 
-func (a *apiProvider) GetProtoFeature(ctx context.Context, key string, namespace string, result proto.Message) error {
+func (a *apiProvider) GetProto(ctx context.Context, key string, namespace string, result proto.Message) error {
 	lc, err := toProto(fromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "error transforming context")
@@ -272,7 +272,7 @@ func (a *apiProvider) GetProtoFeature(ctx context.Context, key string, namespace
 	return resp.Msg.GetValue().UnmarshalTo(result)
 }
 
-func (a *apiProvider) GetJSONFeature(ctx context.Context, key string, namespace string, result interface{}) error {
+func (a *apiProvider) GetJSON(ctx context.Context, key string, namespace string, result interface{}) error {
 	lc, err := toProto(fromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "error transforming context")

--- a/client/api_provider_internal_test.go
+++ b/client/api_provider_internal_test.go
@@ -109,63 +109,63 @@ func testProvider(backendCli *testBackendClient) Provider {
 	}
 }
 
-func TestGetBoolFeature(t *testing.T) {
+func TestGetBoolConfig(t *testing.T) {
 	// success
 	ctx := context.Background()
 	cli := testProvider(&testBackendClient{boolVal: true})
-	result, err := cli.GetBoolFeature(ctx, "test_key", "namespace")
+	result, err := cli.GetBool(ctx, "test_key", "namespace")
 	assert.NoError(t, err)
 	assert.True(t, result)
 
 	// test passing up backend error
 	cli = testProvider(&testBackendClient{err: errors.New("error")})
-	_, err = cli.GetBoolFeature(ctx, "test_key", "namespace")
+	_, err = cli.GetBool(ctx, "test_key", "namespace")
 	assert.Error(t, err)
 }
 
-func TestGetIntFeature(t *testing.T) {
+func TestGetIntConfig(t *testing.T) {
 	// success
 	ctx := context.Background()
 	cli := testProvider(&testBackendClient{intVal: 8})
-	result, err := cli.GetIntFeature(ctx, "test_key", "namespace")
+	result, err := cli.GetInt(ctx, "test_key", "namespace")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(8), result)
 
 	// test passing up backend error
 	cli = testProvider(&testBackendClient{err: errors.New("error")})
-	_, err = cli.GetIntFeature(ctx, "test_key", "namespace")
+	_, err = cli.GetInt(ctx, "test_key", "namespace")
 	assert.Error(t, err)
 }
 
-func TestGetFloatFeature(t *testing.T) {
+func TestGetFloatConfig(t *testing.T) {
 	// success
 	ctx := context.Background()
 	cli := testProvider(&testBackendClient{floatVal: 8.89})
-	result, err := cli.GetFloatFeature(ctx, "test_key", "namespace")
+	result, err := cli.GetFloat(ctx, "test_key", "namespace")
 	assert.NoError(t, err)
 	assert.Equal(t, 8.89, result)
 
 	// test passing up backend error
 	cli = testProvider(&testBackendClient{err: errors.New("error")})
-	_, err = cli.GetFloatFeature(ctx, "test_key", "namespace")
+	_, err = cli.GetFloat(ctx, "test_key", "namespace")
 	assert.Error(t, err)
 }
 
-func TestGetStringFeature(t *testing.T) {
+func TestGetStringConfig(t *testing.T) {
 	// success
 	ctx := context.Background()
 	cli := testProvider(&testBackendClient{stringVal: "foo"})
-	result, err := cli.GetStringFeature(ctx, "test_key", "namespace")
+	result, err := cli.GetString(ctx, "test_key", "namespace")
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", result)
 
 	// test passing up backend error
 	cli = testProvider(&testBackendClient{err: errors.New("error")})
-	_, err = cli.GetStringFeature(ctx, "test_key", "namespace")
+	_, err = cli.GetString(ctx, "test_key", "namespace")
 	assert.Error(t, err)
 }
 
-func TestGetProtoFeature(t *testing.T) {
+func TestGetProtoConfig(t *testing.T) {
 	protoProvider := func(version string, p proto.Message, err error) Provider {
 		if version == "v1" {
 			return testProvider(&testBackendClient{protoVal: p, err: err})
@@ -180,17 +180,17 @@ func TestGetProtoFeature(t *testing.T) {
 			ctx := context.Background()
 			cli := protoProvider(version, wrapperspb.Int64(59), nil)
 			result := &wrapperspb.Int64Value{}
-			require.NoError(t, cli.GetProtoFeature(ctx, "test_key", "namespace", result))
+			require.NoError(t, cli.GetProto(ctx, "test_key", "namespace", result))
 			assert.EqualValues(t, int64(59), result.Value)
 
 			// test passing up backend error
 			cli = protoProvider(version, wrapperspb.Int64(59), errors.New("error"))
-			assert.Error(t, cli.GetProtoFeature(ctx, "test_key", "namespace", result))
+			assert.Error(t, cli.GetProto(ctx, "test_key", "namespace", result))
 
 			// type mismatch in proto value
 			cli = protoProvider(version, wrapperspb.Int64(59), nil)
 			badResult := &wrapperspb.BoolValue{Value: true}
-			assert.Error(t, cli.GetProtoFeature(ctx, "test_key", "namespace", badResult))
+			assert.Error(t, cli.GetProto(ctx, "test_key", "namespace", badResult))
 			// Note: the value of badResult is now undefined and api
 			// behavior may change, so it should not be depended on
 		})
@@ -200,7 +200,7 @@ func TestGetProtoFeature(t *testing.T) {
 func TestUnsupportedContextType(t *testing.T) {
 	ctx := Add(context.Background(), "foo", []string{})
 	cli := testProvider(&testBackendClient{boolVal: true})
-	_, err := cli.GetBoolFeature(ctx, "test_key", "namespace")
+	_, err := cli.GetBool(ctx, "test_key", "namespace")
 	require.Error(t, err)
 }
 
@@ -213,7 +213,7 @@ type testStruct struct {
 	Bar *barType `json:"bar"`
 }
 
-func TestGetJSONFeature(t *testing.T) {
+func TestGetJSONConfig(t *testing.T) {
 	// success
 	ctx := context.Background()
 	ts := &testStruct{Foo: 1, Bar: &barType{Baz: 12}}
@@ -221,38 +221,38 @@ func TestGetJSONFeature(t *testing.T) {
 	require.NoError(t, err)
 	cli := testProvider(&testBackendClient{jsonVal: bytes})
 	result := &testStruct{}
-	require.NoError(t, cli.GetJSONFeature(ctx, "test_key", "namespace", result))
+	require.NoError(t, cli.GetJSON(ctx, "test_key", "namespace", result))
 	assert.EqualValues(t, ts, result)
 
 	// test passing up backend error
 	cli = testProvider(&testBackendClient{jsonVal: bytes, err: errors.New("error")})
-	assert.Error(t, cli.GetJSONFeature(ctx, "test_key", "namespace", result))
+	assert.Error(t, cli.GetJSON(ctx, "test_key", "namespace", result))
 
 	// type mismatch in result
 	cli = testProvider(&testBackendClient{jsonVal: bytes})
 	badResult := new(int)
-	assert.Error(t, cli.GetJSONFeature(ctx, "test_key", "namespace", badResult))
+	assert.Error(t, cli.GetJSON(ctx, "test_key", "namespace", badResult))
 }
 
-func TestGetJSONFeatureArr(t *testing.T) {
+func TestGetJSONConfigArr(t *testing.T) {
 	ctx := context.Background()
 	ts := []int{1, 2, 3}
 	bytes, err := json.Marshal(&ts)
 	require.NoError(t, err)
 	cli := testProvider(&testBackendClient{jsonVal: bytes})
 	result := []int{45}
-	require.NoError(t, cli.GetJSONFeature(ctx, "test_key", "namespace", &result))
+	require.NoError(t, cli.GetJSON(ctx, "test_key", "namespace", &result))
 	assert.EqualValues(t, ts, result)
 }
 
-func TestGetJSONFeatureError(t *testing.T) {
+func TestGetJSONConfigError(t *testing.T) {
 	ctx := context.Background()
 	ts := []int{1, 2, 3}
 	bytes, err := json.Marshal(&ts)
 	require.NoError(t, err)
 	cli := testProvider(&testBackendClient{jsonVal: bytes})
 	result := []string{"foo"}
-	err = cli.GetJSONFeature(ctx, "test_key", "namespace", &result)
+	err = cli.GetJSON(ctx, "test_key", "namespace", &result)
 	assert.Error(t, err)
 	// Note: the value of &result is now undefined and api
 	// behavior may change, so it should not be depended on

--- a/client/cached_provider.go
+++ b/client/cached_provider.go
@@ -106,13 +106,11 @@ type cachedProvider struct {
 	store memory.Store
 }
 
-// Close implements Provider.
 func (cp *cachedProvider) Close(ctx context.Context) error {
 	return cp.store.Close(ctx)
 }
 
-// GetBoolFeature implements Provider.
-func (cp *cachedProvider) GetBoolFeature(ctx context.Context, key string, namespace string) (bool, error) {
+func (cp *cachedProvider) GetBool(ctx context.Context, key string, namespace string) (bool, error) {
 	dest := &wrapperspb.BoolValue{}
 	if err := cp.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
 		return false, err
@@ -120,8 +118,7 @@ func (cp *cachedProvider) GetBoolFeature(ctx context.Context, key string, namesp
 	return dest.GetValue(), nil
 }
 
-// GetFloatFeature implements Provider.
-func (cp *cachedProvider) GetFloatFeature(ctx context.Context, key string, namespace string) (float64, error) {
+func (cp *cachedProvider) GetFloat(ctx context.Context, key string, namespace string) (float64, error) {
 	dest := &wrapperspb.DoubleValue{}
 	if err := cp.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
 		return 0, err
@@ -129,8 +126,7 @@ func (cp *cachedProvider) GetFloatFeature(ctx context.Context, key string, names
 	return dest.GetValue(), nil
 }
 
-// GetIntFeature implements Provider.
-func (cp *cachedProvider) GetIntFeature(ctx context.Context, key string, namespace string) (int64, error) {
+func (cp *cachedProvider) GetInt(ctx context.Context, key string, namespace string) (int64, error) {
 	dest := &wrapperspb.Int64Value{}
 	if err := cp.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
 		return 0, err
@@ -138,8 +134,7 @@ func (cp *cachedProvider) GetIntFeature(ctx context.Context, key string, namespa
 	return dest.GetValue(), nil
 }
 
-// GetJSONFeature implements Provider.
-func (cp *cachedProvider) GetJSONFeature(ctx context.Context, key string, namespace string, result interface{}) error {
+func (cp *cachedProvider) GetJSON(ctx context.Context, key string, namespace string, result interface{}) error {
 	dest := &structpb.Value{}
 	if err := cp.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
 		return err
@@ -154,13 +149,11 @@ func (cp *cachedProvider) GetJSONFeature(ctx context.Context, key string, namesp
 	return nil
 }
 
-// GetProtoFeature implements Provider.
-func (cp *cachedProvider) GetProtoFeature(ctx context.Context, key string, namespace string, result protoreflect.ProtoMessage) error {
+func (cp *cachedProvider) GetProto(ctx context.Context, key string, namespace string, result protoreflect.ProtoMessage) error {
 	return cp.store.Evaluate(key, namespace, fromContext(ctx), result)
 }
 
-// GetStringFeature implements Provider.
-func (cp *cachedProvider) GetStringFeature(ctx context.Context, key string, namespace string) (string, error) {
+func (cp *cachedProvider) GetString(ctx context.Context, key string, namespace string) (string, error) {
 	dest := &wrapperspb.StringValue{}
 	if err := cp.store.Evaluate(key, namespace, fromContext(ctx), dest); err != nil {
 		return "", err

--- a/client/cached_provider_test.go
+++ b/client/cached_provider_test.go
@@ -30,17 +30,17 @@ import (
 
 func makeConfigs() map[string]*anypb.Any {
 	ret := make(map[string]*anypb.Any)
-	bf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true)
+	bf := testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true)
 	ret["bool"] = bf.GetFeature().GetTree().GetDefault()
-	sf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo")
+	sf := testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo")
 	ret["string"] = sf.GetFeature().GetTree().GetDefault()
-	intf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42))
+	intf := testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42))
 	ret["int"] = intf.GetFeature().GetTree().GetDefault()
-	ff := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2))
+	ff := testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2))
 	ret["float"] = ff.GetFeature().GetTree().GetDefault()
-	jf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1.0, 2.0})
+	jf := testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1.0, 2.0})
 	ret["json"] = jf.GetFeature().GetTree().GetDefault()
-	pf := testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58))
+	pf := testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58))
 	ret["proto"] = pf.GetFeature().GetTree().GetDefault()
 	return ret
 }
@@ -53,24 +53,24 @@ func TestInMemoryProviderSuccess(t *testing.T) {
 	}
 	ctx := context.Background()
 	// happy paths
-	br, err := im.GetBoolFeature(ctx, "bool", "")
+	br, err := im.GetBool(ctx, "bool", "")
 	require.NoError(t, err)
 	assert.True(t, br)
-	sr, err := im.GetStringFeature(ctx, "string", "")
+	sr, err := im.GetString(ctx, "string", "")
 	require.NoError(t, err)
 	assert.Equal(t, "foo", sr)
-	ir, err := im.GetIntFeature(ctx, "int", "")
+	ir, err := im.GetInt(ctx, "int", "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), ir)
-	fr, err := im.GetFloatFeature(ctx, "float", "")
+	fr, err := im.GetFloat(ctx, "float", "")
 	require.NoError(t, err)
 	assert.Equal(t, float64(1.2), fr)
 	var result []any
-	err = im.GetJSONFeature(ctx, "json", "", &result)
+	err = im.GetJSON(ctx, "json", "", &result)
 	require.NoError(t, err)
 	assert.EqualValues(t, []any{1.0, 2.0}, result)
 	protoResult := &wrapperspb.Int32Value{}
-	err = im.GetProtoFeature(ctx, "proto", "", protoResult)
+	err = im.GetProto(ctx, "proto", "", protoResult)
 	require.NoError(t, err)
 	assert.EqualValues(t, int32(58), protoResult.Value)
 	require.NoError(t, im.Close(ctx), "no error during close")
@@ -83,29 +83,29 @@ func TestInMemoryProviderTypeMismatch(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	_, err := im.GetStringFeature(ctx, "bool", "")
+	_, err := im.GetString(ctx, "bool", "")
 	require.Error(t, err)
-	_, err = im.GetIntFeature(ctx, "bool", "")
+	_, err = im.GetInt(ctx, "bool", "")
 	require.Error(t, err)
-	_, err = im.GetFloatFeature(ctx, "bool", "")
+	_, err = im.GetFloat(ctx, "bool", "")
 	require.Error(t, err)
 	var result bool
-	err = im.GetJSONFeature(ctx, "bool", "", &result)
+	err = im.GetJSON(ctx, "bool", "", &result)
 	require.Error(t, err)
 	protoResult := &wrapperspb.FloatValue{}
-	err = im.GetProtoFeature(ctx, "bool", "", protoResult)
+	err = im.GetProto(ctx, "bool", "", protoResult)
 	require.Error(t, err)
 	require.NoError(t, im.Close(ctx), "no error during close")
 }
 
-func TestInMemoryProviderMissingFeature(t *testing.T) {
+func TestInMemoryProviderMissingConfig(t *testing.T) {
 	im := &cachedProvider{
 		store: &testStore{
 			configs: makeConfigs(),
 		},
 	}
 	ctx := context.Background()
-	_, err := im.GetBoolFeature(ctx, "missing", "")
+	_, err := im.GetBool(ctx, "missing", "")
 	require.Error(t, err)
 	require.NoError(t, im.Close(ctx), "no error during close")
 }

--- a/client/clienttest/README.md
+++ b/client/clienttest/README.md
@@ -7,9 +7,9 @@ Here is a simple example of how you may use it in a unit test:
 
 ```go
 func TestLekko(t *testing.T) {
-	testClient := NewTestClient().WithBool("bool-feature", true)
+	testClient := NewTestClient().WithBool("namespace", "bool-config", true)
 
-	result, err := testClient.GetBool(context.Background(), "bool-feature")
+	result, err := testClient.GetBool(context.Background(), "namespace", "bool-config")
 	assert.NoError(t, err)
 	assert.True(t, result)
 }

--- a/client/clienttest/client.go
+++ b/client/clienttest/client.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	ErrNotFound     = errors.New("feature not found")
+	ErrNotFound     = errors.New("config not found")
 	ErrTypeMismatch = errors.New("type mismatch")
 )
 
@@ -32,71 +32,82 @@ var (
 // use in unit tests. It conforms to the  See client_test.go for
 // examples on how to use it.
 type TestClient struct {
-	values map[string]interface{}
-	errors map[string]error
+	values map[string]map[string]interface{}
+	errors map[string]map[string]error
 }
 
 // Constructs a TestClient for use in unit tests.
 func NewTestClient() *TestClient {
 	return &TestClient{
-		values: make(map[string]interface{}),
-		errors: map[string]error{},
+		values: make(map[string]map[string]interface{}),
+		errors: make(map[string]map[string]error),
 	}
 }
 
-func (tc *TestClient) WithBool(key string, value bool) *TestClient {
-	return tc.withValue(key, value)
+func (tc *TestClient) WithBool(namespace, key string, value bool) *TestClient {
+	return tc.withValue(namespace, key, value)
 }
 
-func (tc *TestClient) WithString(key string, value string) *TestClient {
-	return tc.withValue(key, value)
+func (tc *TestClient) WithString(namespace, key string, value string) *TestClient {
+	return tc.withValue(namespace, key, value)
 }
 
-func (tc *TestClient) WithInt(key string, value int64) *TestClient {
-	return tc.withValue(key, value)
+func (tc *TestClient) WithInt(namespace, key string, value int64) *TestClient {
+	return tc.withValue(namespace, key, value)
 }
 
-func (tc *TestClient) WithFloat(key string, value float64) *TestClient {
-	return tc.withValue(key, value)
+func (tc *TestClient) WithFloat(namespace, key string, value float64) *TestClient {
+	return tc.withValue(namespace, key, value)
 }
 
 // Accepts a proto-serialized byte array
-func (tc *TestClient) WithProto(key string, value []byte) *TestClient {
-	return tc.withValue(key, value)
+func (tc *TestClient) WithProto(namespace, key string, value []byte) *TestClient {
+	return tc.withValue(namespace, key, value)
 }
 
 // Accepts a JSON-serialized byte array
-func (tc *TestClient) WithJSON(key string, value []byte) *TestClient {
-	return tc.withValue(key, value)
+func (tc *TestClient) WithJSON(namespace, key string, value []byte) *TestClient {
+	return tc.withValue(namespace, key, value)
 }
 
-func (tc *TestClient) WithError(key string, err error) *TestClient {
-	tc.errors[key] = err
+func (tc *TestClient) WithError(namespace, key string, err error) *TestClient {
+	if _, ok := tc.errors[namespace]; !ok {
+		tc.errors[namespace] = make(map[string]error)
+	}
+	tc.errors[namespace][key] = err
 	return tc
 }
 
 // Ensure we conform to the client interface
 var _ client.Client = (*TestClient)(nil)
 
-func (tc *TestClient) withValue(key string, value interface{}) *TestClient {
-	tc.values[key] = value
+func (tc *TestClient) withValue(namespace, key string, value interface{}) *TestClient {
+	if _, ok := tc.values[namespace]; !ok {
+		tc.values[namespace] = make(map[string]interface{})
+	}
+	tc.values[namespace][key] = value
 	return tc
 }
 
-func (tc *TestClient) getValue(key string) (interface{}, error) {
-	err, ok := tc.errors[key]
-	if ok {
-		return nil, err
+func (tc *TestClient) getValue(namespace, key string) (interface{}, error) {
+	if nsErrMap, ok := tc.errors[namespace]; ok {
+		if err, ok := nsErrMap[key]; ok {
+			return nil, err
+		}
 	}
-	val, ok := tc.values[key]
+	nsMap, ok := tc.values[namespace]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	val, ok := nsMap[key]
 	if !ok {
 		return nil, ErrNotFound
 	}
 	return val, nil
 }
 
-func (tc *TestClient) GetBool(_ context.Context, key string) (bool, error) {
-	val, err := tc.getValue(key)
+func (tc *TestClient) GetBool(_ context.Context, namespace, key string) (bool, error) {
+	val, err := tc.getValue(namespace, key)
 	if err != nil {
 		return false, err
 	}
@@ -107,8 +118,8 @@ func (tc *TestClient) GetBool(_ context.Context, key string) (bool, error) {
 	return typedVal, nil
 }
 
-func (tc *TestClient) GetInt(_ context.Context, key string) (int64, error) {
-	val, err := tc.getValue(key)
+func (tc *TestClient) GetInt(_ context.Context, namespace, key string) (int64, error) {
+	val, err := tc.getValue(namespace, key)
 	if err != nil {
 		return 0, err
 	}
@@ -119,8 +130,8 @@ func (tc *TestClient) GetInt(_ context.Context, key string) (int64, error) {
 	return typedVal, nil
 }
 
-func (tc *TestClient) GetFloat(_ context.Context, key string) (float64, error) {
-	val, err := tc.getValue(key)
+func (tc *TestClient) GetFloat(_ context.Context, namespace, key string) (float64, error) {
+	val, err := tc.getValue(namespace, key)
 	if err != nil {
 		return 0, err
 	}
@@ -131,8 +142,8 @@ func (tc *TestClient) GetFloat(_ context.Context, key string) (float64, error) {
 	return typedVal, nil
 }
 
-func (tc *TestClient) GetString(_ context.Context, key string) (string, error) {
-	val, err := tc.getValue(key)
+func (tc *TestClient) GetString(_ context.Context, namespace, key string) (string, error) {
+	val, err := tc.getValue(namespace, key)
 	if err != nil {
 		return "", err
 	}
@@ -143,8 +154,8 @@ func (tc *TestClient) GetString(_ context.Context, key string) (string, error) {
 	return typedVal, nil
 }
 
-func (tc *TestClient) GetProto(_ context.Context, key string, result proto.Message) error {
-	val, err := tc.getValue(key)
+func (tc *TestClient) GetProto(_ context.Context, namespace, key string, result proto.Message) error {
+	val, err := tc.getValue(namespace, key)
 	if err != nil {
 		return err
 	}
@@ -155,8 +166,8 @@ func (tc *TestClient) GetProto(_ context.Context, key string, result proto.Messa
 	return proto.Unmarshal(bytes, result)
 }
 
-func (tc *TestClient) GetJSON(_ context.Context, key string, result interface{}) error {
-	val, err := tc.getValue(key)
+func (tc *TestClient) GetJSON(_ context.Context, namespace, key string, result interface{}) error {
+	val, err := tc.getValue(namespace, key)
 	if err != nil {
 		return err
 	}

--- a/client/clienttest/client_test.go
+++ b/client/clienttest/client_test.go
@@ -27,6 +27,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+var ns = "test-ns"
+
 func TestTestClient(t *testing.T) {
 	// proto
 	protoValue := durationpb.New(time.Hour)
@@ -38,42 +40,42 @@ func TestTestClient(t *testing.T) {
 	require.NoError(t, err)
 
 	testClient := NewTestClient().
-		WithBool("bool-feature", true).
-		WithProto("proto-feature", protoBytes).
-		WithJSON("json-feature", jsonBytes).
-		WithString("repeat-key", "foo").
-		WithError("repeat-key", errors.New("error")).
-		WithFloat("float-feature", 1.0).
-		WithInt("int-feature", 9)
+		WithBool(ns, "bool-config", true).
+		WithProto(ns, "proto-config", protoBytes).
+		WithJSON(ns, "json-config", jsonBytes).
+		WithString(ns, "repeat-key", "foo").
+		WithError(ns, "repeat-key", errors.New("error")).
+		WithFloat(ns, "float-config", 1.0).
+		WithInt(ns, "int-config", 9)
 
 	ctx := context.Background()
 
-	result, err := testClient.GetBool(ctx, "bool-feature")
+	result, err := testClient.GetBool(ctx, ns, "bool-config")
 	assert.NoError(t, err)
 	assert.True(t, result)
 
 	protoResult := &durationpb.Duration{}
-	assert.NoError(t, testClient.GetProto(ctx, "proto-feature", protoResult))
+	assert.NoError(t, testClient.GetProto(ctx, ns, "proto-config", protoResult))
 	assert.True(t, proto.Equal(protoValue, protoResult))
 
 	jsonResult := []int{}
-	assert.NoError(t, testClient.GetJSON(ctx, "json-feature", &jsonResult))
+	assert.NoError(t, testClient.GetJSON(ctx, ns, "json-config", &jsonResult))
 	assert.Equal(t, jsonValue, jsonResult)
 
-	_, err = testClient.GetString(ctx, "repeat-key")
+	_, err = testClient.GetString(ctx, ns, "repeat-key")
 	assert.Error(t, err)
 
-	_, err = testClient.GetInt(ctx, "bool-feature")
+	_, err = testClient.GetInt(ctx, ns, "bool-config")
 	assert.Error(t, err, "expecting type mismatch")
 
-	intResult, err := testClient.GetInt(ctx, "int-feature")
+	intResult, err := testClient.GetInt(ctx, ns, "int-config")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(9), intResult)
 
-	floatResult, err := testClient.GetFloat(ctx, "float-feature")
+	floatResult, err := testClient.GetFloat(ctx, ns, "float-config")
 	assert.NoError(t, err)
 	assert.Equal(t, 1.0, floatResult)
 
-	_, err = testClient.GetBool(ctx, "not-found")
+	_, err = testClient.GetBool(ctx, ns, "not-found")
 	assert.Error(t, err, "expecting not found error")
 }

--- a/client/context.go
+++ b/client/context.go
@@ -21,9 +21,6 @@ import (
 	clientv1beta1 "buf.build/gen/go/lekkodev/sdk/protocolbuffers/go/lekko/client/v1beta1"
 )
 
-// TODO: we need a better name that's not 'context'. Conditions? Features? Values?
-// 'context' is overloaded in go.
-
 // lekkoContext is the type of the value stored in the context
 type lekkoContext map[string]interface{}
 
@@ -36,7 +33,7 @@ type lekkoKey int
 var lekkoKeyV1 lekkoKey
 
 // Merge allows you to pass arbitrary context variables in order to perform
-// rules evaluation on your feature flags in real time.
+// rules evaluation on your configs in real time.
 // Priority is given to newly added keys in lekkoCtx.
 // TODO: allow users to run in safe mode, which will throw errors on ctx conflicts.
 // TODO: this is not thread-safe, make it thread-safe.

--- a/client/provider.go
+++ b/client/provider.go
@@ -29,12 +29,12 @@ import (
 
 // A provider evaluates configuration from a number of sources.
 type Provider interface {
-	GetBoolFeature(ctx context.Context, key string, namespace string) (bool, error)
-	GetIntFeature(ctx context.Context, key string, namespace string) (int64, error)
-	GetFloatFeature(ctx context.Context, key string, namespace string) (float64, error)
-	GetStringFeature(ctx context.Context, key string, namespace string) (string, error)
-	GetProtoFeature(ctx context.Context, key string, namespace string, result proto.Message) error
-	GetJSONFeature(ctx context.Context, key string, namespace string, result interface{}) error
+	GetBool(ctx context.Context, key string, namespace string) (bool, error)
+	GetInt(ctx context.Context, key string, namespace string) (int64, error)
+	GetFloat(ctx context.Context, key string, namespace string) (float64, error)
+	GetString(ctx context.Context, key string, namespace string) (string, error)
+	GetProto(ctx context.Context, key string, namespace string, result proto.Message) error
+	GetJSON(ctx context.Context, key string, namespace string, result interface{}) error
 	// Error will get called by the closure returned in Client initialization.
 	Close(ctx context.Context) error
 }

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -51,20 +51,20 @@ func main() {
 		log.Fatalf("error when starting in %s mode: %v\n", mode, err)
 	}
 
-	cl, closeF := client.NewClient(namespace, provider)
+	cl, closeF := client.NewClient(provider)
 	defer func() {
 		_ = closeF(context.Background())
 	}()
 	var result any
 	switch cfgType {
 	case "string":
-		result, err = cl.GetString(ctx, config)
+		result, err = cl.GetString(ctx, namespace, config)
 	case "int":
-		result, err = cl.GetInt(ctx, config)
+		result, err = cl.GetInt(ctx, namespace, config)
 	case "float":
-		result, err = cl.GetFloat(ctx, config)
+		result, err = cl.GetFloat(ctx, namespace, config)
 	case "bool":
-		result, err = cl.GetBool(ctx, config)
+		result, err = cl.GetBool(ctx, namespace, config)
 	default:
 		log.Fatalf("unknown config type %s\n", cfgType)
 	}

--- a/internal/memory/backend_test.go
+++ b/internal/memory/backend_test.go
@@ -45,12 +45,12 @@ func repositoryContents() *backendv1beta1.GetRepositoryContentsResponse {
 			{
 				Name: "ns-1",
 				Features: []*backendv1beta1.Feature{
-					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true),
-					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo"),
-					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2)),
-					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42)),
-					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1, 2.5, "bar"}),
-					testdata.Feature(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58)),
+					testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_BOOL, true),
+					testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_STRING, "foo"),
+					testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT, float64(1.2)),
+					testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_INT, int64(42)),
+					testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_JSON, []any{1, 2.5, "bar"}),
+					testdata.Config(featurev1beta1.FeatureType_FEATURE_TYPE_PROTO, wrapperspb.Int32(58)),
 				},
 			},
 		},

--- a/pkg/eval/types.go
+++ b/pkg/eval/types.go
@@ -19,76 +19,76 @@ import (
 )
 
 // Indicates the lekko-specific types that are allowed in feature flags.
-type FeatureType string
+type ConfigType string
 
 const (
-	FeatureTypeBool   FeatureType = "bool"
-	FeatureTypeInt    FeatureType = "int"
-	FeatureTypeFloat  FeatureType = "float"
-	FeatureTypeString FeatureType = "string"
-	FeatureTypeProto  FeatureType = "proto"
-	FeatureTypeJSON   FeatureType = "json"
+	ConfigTypeBool   ConfigType = "bool"
+	ConfigTypeInt    ConfigType = "int"
+	ConfigTypeFloat  ConfigType = "float"
+	ConfigTypeString ConfigType = "string"
+	ConfigTypeProto  ConfigType = "proto"
+	ConfigTypeJSON   ConfigType = "json"
 )
 
-func FeatureTypes() []string {
+func ConfigTypes() []string {
 	var ret []string
-	for _, ftype := range []FeatureType{
-		FeatureTypeBool,
-		FeatureTypeString,
-		FeatureTypeInt,
-		FeatureTypeFloat,
-		FeatureTypeJSON,
-		FeatureTypeProto,
+	for _, ctype := range []ConfigType{
+		ConfigTypeBool,
+		ConfigTypeString,
+		ConfigTypeInt,
+		ConfigTypeFloat,
+		ConfigTypeJSON,
+		ConfigTypeProto,
 	} {
-		ret = append(ret, string(ftype))
+		ret = append(ret, string(ctype))
 	}
 	return ret
 }
 
-func (ft FeatureType) ToProto() featurev1beta1.FeatureType {
+func (ft ConfigType) ToProto() featurev1beta1.FeatureType {
 	switch ft {
-	case FeatureTypeBool:
+	case ConfigTypeBool:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_BOOL
-	case FeatureTypeInt:
+	case ConfigTypeInt:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_INT
-	case FeatureTypeFloat:
+	case ConfigTypeFloat:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT
-	case FeatureTypeString:
+	case ConfigTypeString:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_STRING
-	case FeatureTypeJSON:
+	case ConfigTypeJSON:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_JSON
-	case FeatureTypeProto:
+	case ConfigTypeProto:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_PROTO
 	default:
 		return featurev1beta1.FeatureType_FEATURE_TYPE_UNSPECIFIED
 	}
 }
 
-func (ft FeatureType) IsPrimitive() bool {
-	primitiveTypes := map[FeatureType]struct{}{
-		FeatureTypeBool:   {},
-		FeatureTypeString: {},
-		FeatureTypeInt:    {},
-		FeatureTypeFloat:  {},
+func (ft ConfigType) IsPrimitive() bool {
+	primitiveTypes := map[ConfigType]struct{}{
+		ConfigTypeBool:   {},
+		ConfigTypeString: {},
+		ConfigTypeInt:    {},
+		ConfigTypeFloat:  {},
 	}
 	_, ok := primitiveTypes[ft]
 	return ok
 }
 
-func FeatureTypeFromProto(ft featurev1beta1.FeatureType) FeatureType {
+func ConfigTypeFromProto(ft featurev1beta1.FeatureType) ConfigType {
 	switch ft {
 	case featurev1beta1.FeatureType_FEATURE_TYPE_BOOL:
-		return FeatureTypeBool
+		return ConfigTypeBool
 	case featurev1beta1.FeatureType_FEATURE_TYPE_INT:
-		return FeatureTypeInt
+		return ConfigTypeInt
 	case featurev1beta1.FeatureType_FEATURE_TYPE_FLOAT:
-		return FeatureTypeFloat
+		return ConfigTypeFloat
 	case featurev1beta1.FeatureType_FEATURE_TYPE_STRING:
-		return FeatureTypeString
+		return ConfigTypeString
 	case featurev1beta1.FeatureType_FEATURE_TYPE_JSON:
-		return FeatureTypeJSON
+		return ConfigTypeJSON
 	case featurev1beta1.FeatureType_FEATURE_TYPE_PROTO:
-		return FeatureTypeProto
+		return ConfigTypeProto
 	default:
 		return ""
 	}

--- a/testdata/fixtures.go
+++ b/testdata/fixtures.go
@@ -27,10 +27,10 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func ValToAny(featureType featurev1beta1.FeatureType, v any) *anypb.Any {
+func ValToAny(configType featurev1beta1.FeatureType, v any) *anypb.Any {
 	var err error
 	dest := &anypb.Any{}
-	switch featureType {
+	switch configType {
 	case featurev1beta1.FeatureType_FEATURE_TYPE_BOOL:
 		tv, ok := v.(bool)
 		if !ok {
@@ -72,7 +72,7 @@ func ValToAny(featureType featurev1beta1.FeatureType, v any) *anypb.Any {
 		}
 		err = anypb.MarshalFrom(dest, sv, proto.MarshalOptions{})
 	default:
-		err = errors.Errorf("unknown feature type %v", featureType)
+		err = errors.Errorf("unknown feature type %v", configType)
 	}
 	if err != nil {
 		panic(err)
@@ -80,7 +80,7 @@ func ValToAny(featureType featurev1beta1.FeatureType, v any) *anypb.Any {
 	return dest
 }
 
-func Feature(ft featurev1beta1.FeatureType, value any) *backendv1beta1.Feature {
+func Config(ft featurev1beta1.FeatureType, value any) *backendv1beta1.Feature {
 	a := ValToAny(ft, value)
 	parts := strings.Split(ft.String(), "_")
 	name := strings.ToLower(parts[len(parts)-1])


### PR DESCRIPTION
- Support multiple namespaces, by changing the Client interface. The underlying provider supports 
it already
- Naming consistency across the board: `feature` -> `config`

this is a breaking change.
