### PR TITLE
Don't retry registration on CodeUnauthenticated and CodeInvalidArgument

### DIFF
--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -165,6 +165,13 @@ func (b *backendStore) registerWithBackoff(ctx context.Context) (string, error) 
 	var err error
 	op := func() error {
 		resp, err = b.distClient.RegisterClient(ctx, req)
+		var cerr *connect.Error
+		if errors.As(err, &cerr) {
+			if cerr.Code() == connect.CodeUnauthenticated ||
+				cerr.Code() == connect.CodeInvalidArgument {
+				return backoff.Permanent(cerr)
+			}
+		}
 		return err
 	}
 


### PR DESCRIPTION
Before it was retrying until the timeout and was hiding the actual error message:
```
go run cmd/example/main.go --lekko-apikey=some-wrong-key --mode=cached
2023/12/14 10:05:03 error when starting in cached mode: error registering client: deadline_exceeded: context deadline exceeded
```
After:
```
go run cmd/example/main.go --lekko-apikey=some-wrong-key --mode=cached
2023/12/14 11:57:57 error when starting in cached mode: error registering client: unauthenticated: Invalid API key
```