### PR TITLE
fix evaluate_to

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"log"
 	"time"
@@ -29,6 +30,7 @@ func main() {
 	var port int
 	var sleep time.Duration
 	var allowHTTP bool
+	var ctxJSON string
 	flag.StringVar(&key, "lekko-apikey", "", "API key for lekko given to your organization")
 	flag.StringVar(&mode, "mode", "api", "Mode to start the sdk in (api, cached, git, gitlocal)")
 	flag.StringVar(&namespace, "namespace", "default", "namespace to request the config from")
@@ -41,6 +43,7 @@ func main() {
 	flag.DurationVar(&sleep, "sleep", 0, "optional sleep duration to invoke web server")
 	flag.StringVar(&url, "url", "", "optional URL to configure the provider")
 	flag.BoolVar(&allowHTTP, "allow-http", false, "whether or not to allow http/2 requests")
+	flag.StringVar(&ctxJSON, "ctx", "", "config evaluation context, as JSON")
 	flag.Parse()
 
 	var provider client.Provider
@@ -55,6 +58,14 @@ func main() {
 	defer func() {
 		_ = closeF(context.Background())
 	}()
+
+	var ctxMap map[string]any
+	err = json.Unmarshal([]byte(ctxJSON), &ctxMap)
+	if err != nil {
+		log.Fatalf("error parsing context: %v", ctxJSON)
+	}
+	ctx = client.Merge(ctx, ctxMap)
+
 	var result any
 	switch cfgType {
 	case "string":

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 )
 
 require (
-	buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1
-	buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240202195728-0718505adbe5.1
+	buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.10.0-20240206020255-9524ca471ba2.1
+	buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240206020255-9524ca471ba2.1
 	buf.build/gen/go/lekkodev/sdk/bufbuild/connect-go v1.10.0-20230810202034-1c821065b9a0.1
 	buf.build/gen/go/lekkodev/sdk/protocolbuffers/go v1.32.0-20230810202034-1c821065b9a0.1
 	github.com/OneOfOne/xxhash v1.2.8

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1 h1:wIvg7wHKvJxchqJM+/RpewjWF4lu0E9z/VU/JqAi7WE=
 buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1/go.mod h1:siogXpHg2bbsZpEHT0ja4k6jthLmVbD9wfAW3iEHd28=
-buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240202195728-0718505adbe5.1 h1:4u6ZeZBbTVeN0MvwJiwfEPB2woEHI4R3ZzvHNaXkTjo=
-buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240202195728-0718505adbe5.1/go.mod h1:LNkM4Gj80nlWRQQixb04OUCROr44A0dIe5g03kF/wIg=
+buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.10.0-20240206020255-9524ca471ba2.1 h1:wXhk+Tmdw0mImGCPOST+3glahjzZvqK/a3eBs7JTD7Q=
+buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.10.0-20240206020255-9524ca471ba2.1/go.mod h1:u5E9lD7zV9nIGArMoumSwXVY/cxJ8VELNY/JpTwhVlE=
+buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240206020255-9524ca471ba2.1 h1:Rv3mWU75qQScvsF440SWo/PSK1xZUl+x1wH+ND3KIO4=
+buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240206020255-9524ca471ba2.1/go.mod h1:LNkM4Gj80nlWRQQixb04OUCROr44A0dIe5g03kF/wIg=
 buf.build/gen/go/lekkodev/sdk/bufbuild/connect-go v1.10.0-20230810202034-1c821065b9a0.1 h1:J0Bw6bd6GUnWpGp1c2rbTlHg8Ne3G2PKYa3vTxp6SP0=
 buf.build/gen/go/lekkodev/sdk/bufbuild/connect-go v1.10.0-20230810202034-1c821065b9a0.1/go.mod h1:GOhwtQN3rKKGVXxfXwhluFsjltgDTTJsEnIrrzjlUIk=
 buf.build/gen/go/lekkodev/sdk/protocolbuffers/go v1.32.0-20230419180142-0694c10ef23c.1/go.mod h1:ggCoYXofBw/AXklHwuCrDgGRfcKCc/mnna2/yFMpR34=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1 h1:wIvg7wHKvJxchqJM+/RpewjWF4lu0E9z/VU/JqAi7WE=
-buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.9.0-20230713234042-fbaaf4924427.1/go.mod h1:siogXpHg2bbsZpEHT0ja4k6jthLmVbD9wfAW3iEHd28=
 buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.10.0-20240206020255-9524ca471ba2.1 h1:wXhk+Tmdw0mImGCPOST+3glahjzZvqK/a3eBs7JTD7Q=
 buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.10.0-20240206020255-9524ca471ba2.1/go.mod h1:u5E9lD7zV9nIGArMoumSwXVY/cxJ8VELNY/JpTwhVlE=
 buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.32.0-20240206020255-9524ca471ba2.1 h1:Rv3mWU75qQScvsF440SWo/PSK1xZUl+x1wH+ND3KIO4=

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lekkodev/go-sdk/pkg/eval"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -184,8 +185,8 @@ func (s *store) evaluateType(
 }
 
 func (s *store) maybeEvaluateReferencedConfigs(
-	cfg *storedConfig, key string, namespace string, lc map[string]interface{}) (map[string]interface{}, error) {
-	referencedConfigToValueMap := make(map[string]interface{})
+	cfg *storedConfig, key string, namespace string, lc map[string]interface{}) (map[string]*structpb.Value, error) {
+	referencedConfigToValueMap := make(map[string]*structpb.Value)
 	referencedConfigKeys := s.getReferencedConfigKeys(cfg)
 	if len(referencedConfigKeys) > 0 {
 		for configKey := range referencedConfigKeys {
@@ -200,7 +201,7 @@ func (s *store) maybeEvaluateReferencedConfigs(
 			if err != nil {
 				return nil, err
 			}
-			referencedConfigToValueMap[configKey] = referencedDest.GetValue()
+			referencedConfigToValueMap[configKey] = structpb.NewStringValue(referencedDest.Value)
 		}
 	}
 	return referencedConfigToValueMap, nil

--- a/pkg/eval/evaluate.go
+++ b/pkg/eval/evaluate.go
@@ -18,6 +18,7 @@ package eval
 
 import (
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
 	rulesv1beta3 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/rules/v1beta3"
@@ -43,11 +44,11 @@ type ResultPath []int
 type v1beta3 struct {
 	*featurev1beta1.Feature
 	namespace                  string
-	referencedConfigToValueMap map[string]interface{}
+	referencedConfigToValueMap map[string]*structpb.Value
 }
 
 // evaluate constrcutor needs a getter to Config getConfig(key string)
-func NewV1Beta3(f *featurev1beta1.Feature, namespace string, referencedConfigToValueMap map[string]interface{}) EvaluableConfig {
+func NewV1Beta3(f *featurev1beta1.Feature, namespace string, referencedConfigToValueMap map[string]*structpb.Value) EvaluableConfig {
 	return &v1beta3{f, namespace, referencedConfigToValueMap}
 }
 

--- a/pkg/eval/evaluate_fixtures.go
+++ b/pkg/eval/evaluate_fixtures.go
@@ -161,7 +161,7 @@ func rulesMap() map[string]*rulesv1beta3.Rule {
 				Function: &rulesv1beta3.CallExpression_EvaluateTo_{
 					EvaluateTo: &rulesv1beta3.CallExpression_EvaluateTo{
 						ConfigName:  "segments",
-						ConfigValue: "alpha",
+						ConfigValue: newValue("alpha"),
 					},
 				},
 			},
@@ -173,7 +173,7 @@ func rulesMap() map[string]*rulesv1beta3.Rule {
 				Function: &rulesv1beta3.CallExpression_EvaluateTo_{
 					EvaluateTo: &rulesv1beta3.CallExpression_EvaluateTo{
 						ConfigName:  "segments",
-						ConfigValue: "beta",
+						ConfigValue: newValue("beta"),
 					},
 				},
 			},

--- a/pkg/eval/evaluate_test.go
+++ b/pkg/eval/evaluate_test.go
@@ -19,6 +19,7 @@ import (
 
 	featurev1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/feature/v1beta1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -138,28 +139,28 @@ func TestEvaluateFeatureWithDependencyV1Beta3(t *testing.T) {
 	complexFeature := NewDependencyTreeFeature()
 	tcs := []struct {
 		context                    map[string]interface{}
-		referencedConfigToValueMap map[string]interface{}
+		referencedConfigToValueMap map[string]*structpb.Value
 		testVal                    int64
 		testPath                   []int
 	}{
 		{
 			nil,
-			map[string]interface{}{dependentConfigName: "gamma"},
+			map[string]*structpb.Value{dependentConfigName: newValue("gamma")},
 			50, []int{},
 		},
 		{
 			map[string]interface{}{"a": 6},
-			map[string]interface{}{dependentConfigName: "beta"},
+			map[string]*structpb.Value{dependentConfigName: newValue("beta")},
 			20, []int{1},
 		},
 		{
 			map[string]interface{}{"a": 6},
-			map[string]interface{}{dependentConfigName: "alpha"},
+			map[string]*structpb.Value{dependentConfigName: newValue("alpha")},
 			10, []int{0},
 		},
 		{
 			map[string]interface{}{"a": 4},
-			map[string]interface{}{dependentConfigName: "beta"},
+			map[string]*structpb.Value{dependentConfigName: newValue("beta")},
 			30, []int{2},
 		},
 	}

--- a/pkg/rules/functions.go
+++ b/pkg/rules/functions.go
@@ -32,7 +32,7 @@ func (v1b3 *v1beta3) evaluateEvaluateTo(
 	if !present {
 		return false, errors.Errorf("config name %s for evaluate_to not found", evaluateToF.ConfigName)
 	}
-	return expectedValue == actualValue, nil
+	return expectedValue.AsInterface() == actualValue.AsInterface(), nil
 }
 
 // If the hashed feature value % 100 <= threshold, it fits in the "bucket".

--- a/pkg/rules/v1beta3.go
+++ b/pkg/rules/v1beta3.go
@@ -34,7 +34,7 @@ var (
 type EvalContext struct {
 	Namespace                  string
 	FeatureName                string
-	ReferencedConfigToValueMap map[string]interface{}
+	ReferencedConfigToValueMap map[string]*structpb.Value
 }
 
 // v1beta3 refers to the version of the rules protobuf type in lekko.rules.v1beta3.rules.proto


### PR DESCRIPTION
It looks like `rules.proto` wasn't updated to the latest version, config values in `referencedConfigToValueMap` should be wrapped into `structpb.Value` to be comparable with value from the rule.