### PR TITLE
debug mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,14 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
   forbidigo:
     forbid:
       - '^log\.'
-      - '^print$'
-      - '^println$'
+      - "^print$"
+      - "^println$"
       # - '^fmt\.Print'
 issues:
+  exclude-dirs-use-default: false
   exclude-rules:
     - path: cmd/example/main.go
       text: "use of `log.Fatal` forbidden by pattern"
@@ -31,6 +30,8 @@ issues:
       text: "use of `log.Printf` forbidden by pattern"
     - path: internal/memory/events.go
       text: "Non-inherited new context"
+    - path: pkg/debug/debug.go
+      text: "don't use `init` function"
 linters:
   enable:
     - asciicheck
@@ -38,7 +39,6 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     # - depguard
     - dogsled
@@ -69,12 +69,10 @@ linters:
     - promlinter
     - rowserrcheck
     - staticcheck
-    - structcheck
-      #  - stylecheck
+    - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
   disable-all: true

--- a/client/api_provider.go
+++ b/client/api_provider.go
@@ -49,7 +49,7 @@ func ConnectAPIProvider(ctx context.Context, apiKey string, rk *RepositoryKey, o
 	withFallbackURL(defaultAPIURL).apply(cfg)
 	WithAPIKey(apiKey).apply(cfg)
 	withRepositoryKey(rk).apply(cfg)
-	if err := cfg.validate(ctx); err != nil {
+	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
 	provider := &apiProvider{
@@ -77,7 +77,7 @@ func ConnectSidecarProvider(ctx context.Context, url string, rk *RepositoryKey, 
 	withFallbackURL(defaultSidecarURL).apply(cfg)
 	withRepositoryKey(rk).apply(cfg)
 	WithAllowHTTP().apply(cfg) // sidecar must communicate over h2c
-	if err := cfg.validate(ctx); err != nil {
+	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
 	// The sidecar exposes the same interface as the backend API, so we can transparently

--- a/client/cached_provider.go
+++ b/client/cached_provider.go
@@ -45,7 +45,7 @@ func CachedAPIProvider(
 	}
 	withFallbackURL(defaultAPIURL).apply(cfg)
 	withRepositoryKey(rk).apply(cfg)
-	if err := cfg.validate(ctx); err != nil {
+	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
 
@@ -84,7 +84,7 @@ func CachedGitFsProvider(
 	if len(cfg.apiKey) > 0 {
 		withFallbackURL(defaultAPIURL).apply(cfg)
 	}
-	if err := cfg.validate(ctx); err != nil {
+	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
 	gitStore, err := memory.NewGitStore(

--- a/client/noop_provider.go
+++ b/client/noop_provider.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var ErrNoOpProvider = errors.New("no op provider")
+
+type noOpProvider struct{}
+
+func (p *noOpProvider) GetBool(ctx context.Context, key string, namespace string) (bool, error) {
+	return false, ErrNoOpProvider
+}
+func (p *noOpProvider) GetInt(ctx context.Context, key string, namespace string) (int64, error) {
+	return 0, ErrNoOpProvider
+}
+func (p *noOpProvider) GetFloat(ctx context.Context, key string, namespace string) (float64, error) {
+	return 0, ErrNoOpProvider
+}
+func (p *noOpProvider) GetString(ctx context.Context, key string, namespace string) (string, error) {
+	return "", ErrNoOpProvider
+}
+func (p *noOpProvider) GetProto(ctx context.Context, key string, namespace string, result proto.Message) error {
+	return ErrNoOpProvider
+}
+func (p *noOpProvider) GetJSON(ctx context.Context, key string, namespace string, result interface{}) error {
+	return ErrNoOpProvider
+}
+func (p *noOpProvider) GetAny(ctx context.Context, key string, namespace string) (protoreflect.ProtoMessage, error) {
+	return nil, ErrNoOpProvider
+}
+func (p *noOpProvider) Close(ctx context.Context) error {
+	return nil
+}

--- a/client/provider.go
+++ b/client/provider.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -43,6 +44,7 @@ type Provider interface {
 
 type ProviderOption interface {
 	apply(*providerConfig)
+	String() string
 }
 
 type URLOption struct {
@@ -58,6 +60,10 @@ func WithURL(url string) ProviderOption {
 
 func (o *URLOption) apply(pc *providerConfig) { pc.url = o.URL }
 
+func (o *URLOption) String() string {
+	return fmt.Sprintf("%+v", *o)
+}
+
 type APIKeyOption struct {
 	APIKey string
 }
@@ -70,6 +76,10 @@ func WithAPIKey(apiKey string) ProviderOption {
 
 func (o *APIKeyOption) apply(pc *providerConfig) { pc.apiKey = o.APIKey }
 
+func (o *APIKeyOption) String() string {
+	return fmt.Sprintf("%+v", *o)
+}
+
 type AllowHTTPOption struct{}
 
 // For connecting to the sidecar without TLS configured.
@@ -78,6 +88,10 @@ func WithAllowHTTP() ProviderOption {
 }
 
 func (o *AllowHTTPOption) apply(pc *providerConfig) { pc.allowHTTP = true }
+
+func (o *AllowHTTPOption) String() string {
+	return fmt.Sprintf("%+v", *o)
+}
 
 type UpdateIntervalOption struct {
 	UpdateInterval time.Duration
@@ -93,6 +107,10 @@ func (o *UpdateIntervalOption) apply(pc *providerConfig) {
 	pc.updateInterval = o.UpdateInterval
 }
 
+func (o *UpdateIntervalOption) String() string {
+	return fmt.Sprintf("%+v", *o)
+}
+
 type ServerOption struct {
 	Port int32
 }
@@ -105,6 +123,10 @@ func WithServerOption(port int32) ProviderOption {
 
 func (o *ServerOption) apply(pc *providerConfig) { pc.serverPort = o.Port }
 
+func (o *ServerOption) String() string {
+	return fmt.Sprintf("%+v", *o)
+}
+
 type providerConfig struct {
 	repoKey        *RepositoryKey
 	apiKey, url    string
@@ -113,7 +135,7 @@ type providerConfig struct {
 	allowHTTP      bool
 }
 
-func (cfg *providerConfig) validate(ctx context.Context) error {
+func (cfg *providerConfig) validate() error {
 	if cfg.repoKey == nil || len(cfg.repoKey.OwnerName) == 0 || len(cfg.repoKey.RepoName) == 0 {
 		return errors.New("missing repository key")
 	}
@@ -164,6 +186,10 @@ func (o *fallbackURLOption) apply(pc *providerConfig) {
 	}
 }
 
+func (o *fallbackURLOption) String() string {
+	return fmt.Sprintf("%+v", *o)
+}
+
 type repositoryKeyOption struct {
 	repoKey *RepositoryKey
 }
@@ -174,4 +200,8 @@ func withRepositoryKey(repoKey *RepositoryKey) ProviderOption {
 
 func (o *repositoryKeyOption) apply(cfg *providerConfig) {
 	cfg.repoKey = o.repoKey
+}
+
+func (o *repositoryKeyOption) String() string {
+	return fmt.Sprintf("%+v", *o)
 }

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -26,6 +26,7 @@ import (
 	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
 	"github.com/bufbuild/connect-go"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/lekkodev/go-sdk/pkg/debug"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -122,7 +123,7 @@ func (b *backendStore) Close(ctx context.Context) error {
 	// cancel any ongoing background loops
 	b.cancel()
 	b.server.close(ctx)
-	b.eb.close(ctx)
+	b.eb.close()
 	// wait for background work to complete
 	b.wg.Wait()
 	req := connect.NewRequest(&backendv1beta1.DeregisterClientRequest{
@@ -139,6 +140,7 @@ func (b *backendStore) Evaluate(key string, namespace string, lc map[string]inte
 	if err != nil {
 		return err
 	}
+	debug.LogInfo("Lekko evaluation", "name", fmt.Sprintf("%s/%s", namespace, key), "context", lc, "result", dest)
 	// track metrics
 	b.eb.track(&backendv1beta1.FlagEvaluationEvent{
 		RepoKey:       b.repoKey,

--- a/internal/memory/events.go
+++ b/internal/memory/events.go
@@ -130,7 +130,7 @@ func (e *eventBatcher) sendBatchWithBackoff(ctx context.Context, batch []*backen
 	}
 }
 
-func (e *eventBatcher) close(ctx context.Context) error {
+func (e *eventBatcher) close() error {
 	if e == nil {
 		return nil
 	}

--- a/internal/memory/git.go
+++ b/internal/memory/git.go
@@ -95,7 +95,7 @@ func newGitStore(
 		g.sessionKey = sessionKey
 		g.eb = newEventBatcher(ctx, distClient, g.sessionKey, g.apiKey, eventsBatchSize)
 	}
-	if _, err := g.load(ctx); err != nil {
+	if _, err := g.load(); err != nil {
 		return nil, err
 	}
 	g.server = newSDKServer(port, g.store)
@@ -153,7 +153,7 @@ func (g *gitStore) registerWithBackoff(ctx context.Context) (string, error) {
 	return sessionKey, nil
 }
 
-func (g *gitStore) load(ctx context.Context) (bool, error) {
+func (g *gitStore) load() (bool, error) {
 	repo, err := newRepository(g.storer, g.fs)
 	if err != nil {
 		return false, err
@@ -183,7 +183,7 @@ func (g *gitStore) watch(ctx context.Context, fsChan <-chan notify.EventInfo) {
 		case <-ctx.Done():
 			return
 		case <-fsChan:
-			_, err := g.load(ctx)
+			_, err := g.load()
 			if err != nil {
 				log.Printf("error loading contents: %v\n", err)
 			}
@@ -218,7 +218,7 @@ func (g *gitStore) Close(ctx context.Context) error {
 	// cancel any ongoing background loops
 	g.cancel()
 	g.server.close(ctx)
-	g.eb.close(ctx)
+	g.eb.close()
 	if g.fsChan != nil {
 		notify.Stop(g.fsChan)
 		close(g.fsChan)

--- a/internal/memory/static.go
+++ b/internal/memory/static.go
@@ -51,7 +51,7 @@ func (s *staticStore) EvaluateAny(key string, namespace string, lc map[string]in
 }
 
 func (s *staticStore) Evaluate(key string, namespace string, lekkoContext map[string]interface{}, dest proto.Message) error {
-	var typeUrl string
+	var typeURL string
 	var targetFieldNumber uint64
 	targetFieldNumber = 0
 	for { // TODO - stop loops (especially for server side eval..
@@ -78,7 +78,7 @@ func (s *staticStore) Evaluate(key string, namespace string, lekkoContext map[st
 				b = b[n:]
 				switch fid {
 				case 1:
-					typeUrl, n = protowire.ConsumeString(b)
+					typeURL, n = protowire.ConsumeString(b)
 				case 2:
 					namespace, n = protowire.ConsumeString(b)
 				case 3:
@@ -111,7 +111,7 @@ func (s *staticStore) Evaluate(key string, namespace string, lekkoContext map[st
 						value = protowire.AppendTag(value, 1, protowire.BytesType)
 						value = protowire.AppendBytes(value, b[:n])
 						a = &anypb.Any{
-							TypeUrl: typeUrl,
+							TypeUrl: typeURL,
 							Value:   value,
 						}
 						return a.UnmarshalTo(dest) // TODO default values and do we want to support deeper nesting?

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -175,7 +175,7 @@ func (s *store) getCommitSha() string {
 }
 
 func (s *store) evaluate(key string, namespace string, lc map[string]interface{}) (*anypb.Any, *storedConfig, eval.ResultPath, error) {
-	var typeUrl string
+	var typeURL string
 	var targetFieldNumber uint64
 	targetFieldNumber = 0
 	for { //TODO - stop loops (especially for server side eval..
@@ -205,7 +205,7 @@ func (s *store) evaluate(key string, namespace string, lc map[string]interface{}
 				b = b[n:]
 				switch fid {
 				case 1:
-					typeUrl, n = protowire.ConsumeString(b)
+					typeURL, n = protowire.ConsumeString(b)
 				case 2:
 					namespace, n = protowire.ConsumeString(b)
 				case 3:
@@ -238,7 +238,7 @@ func (s *store) evaluate(key string, namespace string, lc map[string]interface{}
 						value = protowire.AppendTag(value, 1, protowire.BytesType)
 						value = protowire.AppendBytes(value, b[:n])
 						a = &anypb.Any{
-							TypeUrl: typeUrl,
+							TypeUrl: typeURL,
 							Value:   value,
 						}
 						break // TODO default values and do we want to support deeper nesting?

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20220517 checked 20220520
+# https://github.com/golangci/golangci-lint/releases
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.53.3
+GOLANGCI_LINT_VERSION ?= v1.59.1
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"log/slog"
+	"os"
+)
+
+func LogInfo(msg string, args ...any) {
+	if isDebugMode {
+		slog.Info(msg, args...)
+	}
+}
+
+func LogError(msg string, args ...any) {
+	if isDebugMode {
+		slog.Error(msg, args...)
+	}
+}
+
+// just a switch for now, later we can expose log level and ability to set custom logger
+var isDebugMode = os.Getenv("LEKKO_DEBUG") == "true"
+
+func init() {
+	LogInfo("LEKKO_DEBUG=true, running with additional logging")
+}


### PR DESCRIPTION
Changes:
- I decided to wrap `slog` because it's the most promising and flexible way to do logging in go. For now we use global logger, so any otel bridge or custom handler will be applied to lekko logs. Later we can expose a way to set lekko-specific logger.
- Added `LogInfo` and `LogError` that wrap `slog.Info` and `slog.Error` respectfully and have the same API
- It has to be in a separate package `pkg/debug` so it can be used both inside the SDK and in generated code.

Logging events:
- log that debug mode is enabled
- On initialization, print repo, opts and error (in case of failure)
- evaluation
- fallback

Examples:
```
❯ : LEKKO_DEBUG=true go run main.go
2024/07/08 15:06:43 INFO LEKKO_DEBUG=true, running in debug mode
2024/07/08 15:06:43 INFO LEKKO_API_KEY environment variable is not set, in-code fallback will be used
2024/07/08 15:06:49 INFO Lekko fallback result=ROOT
```

```
2024/07/08 15:25:03 INFO LEKKO_DEBUG=true, running in debug mode
2024/07/08 15:25:03 INFO Connected to Lekko repository=passichenko-lekko-1/lekko-configs opts=[{APIKey:lekko_3ff48a26-7d69-4868-b019-a46df6fafb87_5663e76f-040e-48c6-bf52-497a4bb824a3}]
2024/07/08 15:25:04 INFO Lekko evaluation name=default/title context=map[env:production] result="value:\"Hello from Lekko!\""
2024/07/08 15:25:04 INFO Lekko evaluation name=default/root-message context=map[] result="value:\"MY ROOT\""
```