### PR TITLE
Debug mode improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This SDK is intended to be used with Lekko’s code transformation tools. Make s
 
 ## Prerequisites
 
-- Go version 1.19 or greater
+- Go version 1.21 or greater
 - After running the Lekko Getting Started guide, you should have:
   - The Lekko CLI installed
   - A `.lekko` file at the project root, pointing to a lekko directory in the project (e.g. `internal/lekko`) and a lekko repository

--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,8 @@ func NewClientFromEnv(ctx context.Context, repoOwner, repoName string, opts ...P
 		for i, opt := range opts {
 			serializedOpts[i] = fmt.Sprintf("%v", opt)
 		}
-		serializedOpts[len(opts)] = debug.Mask(apiKey, 12)
+		// Mask and trim for brevity
+		serializedOpts[len(opts)] = debug.Mask(apiKey, 12)[:min(len(apiKey), 24)]
 		opts = append(opts, WithAPIKey(apiKey))
 		var err error
 		provider, err = CachedAPIProvider(ctx, &RepositoryKey{

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -168,6 +168,7 @@ func (b *backendStore) EvaluateAny(key string, namespace string, lc map[string]i
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal any message: %v", err)
 	}
+	debug.LogDebug("Lekko evaluation", "name", fmt.Sprintf("%s/%s", namespace, key), "context", lc, "result", message)
 	b.eb.track(&backendv1beta1.FlagEvaluationEvent{
 		RepoKey:       b.repoKey,
 		CommitSha:     cfg.CommitSHA,


### PR DESCRIPTION
- Added better handling of primitive values in evaluation logs (unwrapping wrapper types)
- Added logs for proto values
- Trimmed API key logging somewhat

Chose not to try to unescape the JSON-marshalled contexts. It turns out it's better-suited for if you're using an e.g. JSON handler for slog.