### PR TITLE
Fix and switch to using retry provider by default

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -78,13 +78,13 @@ func NewClientFromEnv(ctx context.Context, repoOwner, repoName string, opts ...P
 		serializedOpts[len(opts)] = debug.Mask(apiKey, 12)[:min(len(apiKey), 24)]
 		opts = append(opts, WithAPIKey(apiKey))
 		var err error
-		provider, err = CachedAPIProvider(ctx, &RepositoryKey{
+		rk := &RepositoryKey{
 			OwnerName: repoOwner,
 			RepoName:  repoName,
-		}, opts...)
+		}
+		provider, err = RetryProvider(CachedAPIProvider, ctx, rk, opts...)
 		if err != nil {
 			debug.LogError("Error connecting to Lekko, in-code fallback will be used", "opts", serializedOpts, "err", err)
-			provider = &noOpProvider{}
 		} else {
 			debug.LogInfo("Connected to Lekko", "repository", fmt.Sprintf("%s/%s", repoOwner, repoName), "opts", serializedOpts)
 		}

--- a/client/retry_provider.go
+++ b/client/retry_provider.go
@@ -38,15 +38,18 @@ func makeProvider(
 	p, err := f(ctx, rk, opts...)
 	if err != nil {
 		if delay <= 60*time.Second {
-			delay = time.Duration(float64(delay) * 1.5)
+			delay = time.Duration(min(float64(delay)*1.5, float64(60*time.Second)))
 		}
 		debug.LogInfo("Attempting to connect to Lekko", "delay", delay.Seconds())
 		rp.lastError = err
-		go makeProvider(rp, delay, f, ctx, rk, opts...)
 		time.Sleep(delay)
+		go makeProvider(rp, delay, f, ctx, rk, opts...)
 	} else {
 		rp.Lock()
 		rp.inner = p
+		if rp.lastError != nil {
+			debug.LogInfo("Successfully reconnected to Lekko")
+		}
 		rp.Unlock()
 	}
 }

--- a/client/retry_provider.go
+++ b/client/retry_provider.go
@@ -16,10 +16,10 @@ package client
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
+	"github.com/lekkodev/go-sdk/pkg/debug"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -40,6 +40,7 @@ func makeProvider(
 		if delay <= 60*time.Second {
 			delay = time.Duration(float64(delay) * 1.5)
 		}
+		debug.LogInfo("Attempting to connect to Lekko", "delay", delay.Seconds())
 		rp.lastError = err
 		go makeProvider(rp, delay, f, ctx, rk, opts...)
 		time.Sleep(delay)
@@ -78,7 +79,7 @@ func (p *retryProvider) Close(ctx context.Context) error {
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return errors.New("Uninitialized")
+		return ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.Close(ctx)
@@ -88,7 +89,7 @@ func (p *retryProvider) GetBool(ctx context.Context, key string, namespace strin
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return false, errors.New("Uninitialized")
+		return false, ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.GetBool(ctx, key, namespace)
@@ -98,7 +99,7 @@ func (p *retryProvider) GetFloat(ctx context.Context, key string, namespace stri
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return 0, errors.New("Uninitialized")
+		return 0, ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.GetFloat(ctx, key, namespace)
@@ -108,7 +109,7 @@ func (p *retryProvider) GetInt(ctx context.Context, key string, namespace string
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return 0, errors.New("Uninitialized")
+		return 0, ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.GetInt(ctx, key, namespace)
@@ -118,7 +119,7 @@ func (p *retryProvider) GetJSON(ctx context.Context, key string, namespace strin
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return errors.New("Uninitialized")
+		return ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.GetJSON(ctx, key, namespace, result)
@@ -128,7 +129,7 @@ func (p *retryProvider) GetProto(ctx context.Context, key string, namespace stri
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return errors.New("Uninitialized")
+		return ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.GetProto(ctx, key, namespace, result)
@@ -138,12 +139,18 @@ func (p *retryProvider) GetString(ctx context.Context, key string, namespace str
 	p.RLock()
 	if p.inner == nil {
 		p.RUnlock()
-		return "", errors.New("Uninitialized")
+		return "", ErrNoOpProvider
 	}
 	p.RUnlock()
 	return p.inner.GetString(ctx, key, namespace)
 }
 
 func (p *retryProvider) GetAny(ctx context.Context, key string, namespace string) (protoreflect.ProtoMessage, error) {
-	return nil, nil
+	p.RLock()
+	if p.inner == nil {
+		p.RUnlock()
+		return nil, ErrNoOpProvider
+	}
+	p.RUnlock()
+	return p.inner.GetAny(ctx, key, namespace)
 }

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -17,7 +17,6 @@ package memory
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -269,7 +268,7 @@ func (b *backendStore) loop(ctx context.Context) {
 			case <-tick.C:
 				should, err := b.shouldUpdateStore(ctx)
 				if err != nil {
-					log.Printf("failed to compare repo version: %v", err)
+					debug.LogError("Failed to check for Lekko updates", "err", err)
 					continue
 				}
 				if !should {
@@ -277,7 +276,7 @@ func (b *backendStore) loop(ctx context.Context) {
 				}
 				_, err = b.updateStoreWithBackoff(ctx)
 				if err != nil {
-					log.Printf("failed to update store: %v", err)
+					debug.LogError("Failed to fetch updates from Lekko", "err", err)
 					continue
 				}
 			}

--- a/internal/memory/events.go
+++ b/internal/memory/events.go
@@ -16,7 +16,6 @@ package memory
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 	backendv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/backend/v1beta1"
 	"github.com/bufbuild/connect-go"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/lekkodev/go-sdk/pkg/debug"
 )
 
 const (
@@ -126,7 +126,7 @@ func (e *eventBatcher) sendBatchWithBackoff(ctx context.Context, batch []*backen
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 3 * time.Second
 	if err := backoff.Retry(op, b); err != nil {
-		log.Printf("error sending metrics batch: %v", err)
+		debug.LogError("Failed to send Lekko evaluation events", "err", err)
 	}
 }
 


### PR DESCRIPTION
For initial client initialization, we want to have retry logic if Lekko's services can't be reached for whatever reason.

This PR:
- Fixes bug in retry provider that was causing it to not delay correctly
- Updates retry provider to actually cap at 60 seconds delay (we should eventually switch to more flexible exponential backoff (with exposed options for users)
- Adds debug logs for retrying and succeeding
- Replaces older log calls with new debug log methods